### PR TITLE
Fix #67 - system-aware light/dark mode toggle

### DIFF
--- a/PLANNED_FEATURE_ROADMAP_2026.md
+++ b/PLANNED_FEATURE_ROADMAP_2026.md
@@ -14,6 +14,9 @@ Legend
 - **Post-MVP** — required to make the product pleasant for daily use.
 - **Enterprise** — only relevant to multi-tenant cloud or on-prem enterprise installs.
 
+Completed
+- #67 - Added system-aware light/dark mode with a top-right header toggle in the web app.
+
 ---
 
 

--- a/apps/web/.eslintrc.json
+++ b/apps/web/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["next/core-web-vitals", "next/typescript"]
+}

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ouroboros-web",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "scripts": {
     "dev": "next dev -p 3000",

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -1,7 +1,7 @@
 import "./globals.css";
 import type { ReactNode } from "react";
-import { Theme } from "@radix-ui/themes";
 import { TopHeader } from "@/components/layout/top-header";
+import { AppThemeProvider } from "@/components/theme/app-theme-provider";
 
 export const metadata = {
   title: "Ouroboros",
@@ -12,12 +12,12 @@ export default function RootLayout({ children }: { children: ReactNode }) {
   return (
     <html lang="en" suppressHydrationWarning>
       <body>
-        <Theme accentColor="iris" grayColor="slate" radius="medium" appearance="dark">
+        <AppThemeProvider>
           <div className="app-shell">
             <TopHeader />
             <div className="app-body">{children}</div>
           </div>
-        </Theme>
+        </AppThemeProvider>
       </body>
     </html>
   );

--- a/apps/web/src/components/layout/top-header.tsx
+++ b/apps/web/src/components/layout/top-header.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { Flex, Text, Badge } from "@radix-ui/themes";
+import { Flex, Text, Badge, IconButton } from "@radix-ui/themes";
 import {
   FolderTree,
   ListTodo,
@@ -12,7 +12,10 @@ import {
   Boxes,
   Workflow,
   Infinity as InfinityIcon,
+  Moon,
+  Sun,
 } from "lucide-react";
+import { useThemePreference } from "@/components/theme/app-theme-provider";
 
 const NAV: Array<{ href: string; label: string; Icon: typeof FolderTree }> = [
   { href: "/projects", label: "Projects", Icon: FolderTree },
@@ -26,6 +29,9 @@ const NAV: Array<{ href: string; label: string; Icon: typeof FolderTree }> = [
 
 export function TopHeader() {
   const pathname = usePathname();
+  const { appearance, toggleTheme } = useThemePreference();
+  const nextModeLabel = appearance === "dark" ? "light" : "dark";
+
   return (
     <Flex
       align="center"
@@ -65,6 +71,15 @@ export function TopHeader() {
         })}
       </Flex>
       <Flex align="center" gap="2">
+        <IconButton
+          aria-label={`Switch to ${nextModeLabel} mode`}
+          title={`Switch to ${nextModeLabel} mode`}
+          variant="soft"
+          color="gray"
+          onClick={toggleTheme}
+        >
+          {appearance === "dark" ? <Sun size={16} /> : <Moon size={16} />}
+        </IconButton>
         <Badge color="gray" variant="soft">default workspace</Badge>
       </Flex>
     </Flex>

--- a/apps/web/src/components/theme/app-theme-provider.test.tsx
+++ b/apps/web/src/components/theme/app-theme-provider.test.tsx
@@ -1,0 +1,137 @@
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { AppThemeProvider, useThemePreference } from "./app-theme-provider";
+
+declare global {
+  // eslint-disable-next-line no-var
+  var IS_REACT_ACT_ENVIRONMENT: boolean | undefined;
+}
+
+type MockMediaQueryList = MediaQueryList & {
+  dispatch: (matches: boolean) => void;
+};
+
+function installMatchMediaMock(initialMatches: boolean): MockMediaQueryList {
+  const listeners = new Set<(event: MediaQueryListEvent) => void>();
+
+  const mediaQueryList = {
+    media: "(prefers-color-scheme: dark)",
+    matches: initialMatches,
+    onchange: null,
+    addEventListener: (_event: "change", listener: (event: MediaQueryListEvent) => void) => {
+      listeners.add(listener);
+    },
+    removeEventListener: (_event: "change", listener: (event: MediaQueryListEvent) => void) => {
+      listeners.delete(listener);
+    },
+    addListener: (listener: (event: MediaQueryListEvent) => void) => {
+      listeners.add(listener);
+    },
+    removeListener: (listener: (event: MediaQueryListEvent) => void) => {
+      listeners.delete(listener);
+    },
+    dispatchEvent: () => true,
+    dispatch: (matches: boolean) => {
+      mediaQueryList.matches = matches;
+      const event = { matches } as MediaQueryListEvent;
+      for (const listener of listeners) {
+        listener(event);
+      }
+    },
+  } as MockMediaQueryList;
+
+  vi.stubGlobal("matchMedia", vi.fn(() => mediaQueryList));
+  return mediaQueryList;
+}
+
+function ThemeProbe() {
+  const { appearance, preference, toggleTheme } = useThemePreference();
+  return (
+    <div>
+      <span data-testid="appearance">{appearance}</span>
+      <span data-testid="preference">{preference}</span>
+      <button type="button" onClick={toggleTheme}>toggle</button>
+    </div>
+  );
+}
+
+function renderThemeProbe() {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+
+  act(() => {
+    root.render(
+      <AppThemeProvider>
+        <ThemeProbe />
+      </AppThemeProvider>,
+    );
+  });
+
+  return {
+    getAppearance: () => container.querySelector("[data-testid='appearance']")?.textContent,
+    getPreference: () => container.querySelector("[data-testid='preference']")?.textContent,
+    toggle: () => {
+      const button = container.querySelector("button");
+      if (!(button instanceof HTMLButtonElement)) {
+        throw new Error("toggle button missing");
+      }
+      act(() => {
+        button.click();
+      });
+    },
+    cleanup: () => {
+      act(() => {
+        root.unmount();
+      });
+      container.remove();
+    },
+  };
+}
+
+describe("AppThemeProvider", () => {
+  beforeEach(() => {
+    vi.unstubAllGlobals();
+    globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+    window.localStorage.clear();
+    document.body.innerHTML = "";
+  });
+
+  it("follows system preference when no override is stored", async () => {
+    const mediaQueryList = installMatchMediaMock(true);
+    const view = renderThemeProbe();
+
+    expect(view.getPreference()).toBe("system");
+    expect(view.getAppearance()).toBe("dark");
+
+    act(() => {
+      mediaQueryList.dispatch(false);
+    });
+
+    await vi.waitFor(() => {
+      expect(view.getAppearance()).toBe("light");
+    });
+
+    view.cleanup();
+  });
+
+  it("uses stored override and persists manual toggle", async () => {
+    installMatchMediaMock(true);
+    window.localStorage.setItem("ouroboros-theme-preference", "light");
+    const view = renderThemeProbe();
+
+    expect(view.getPreference()).toBe("light");
+    expect(view.getAppearance()).toBe("light");
+
+    view.toggle();
+
+    await vi.waitFor(() => {
+      expect(view.getAppearance()).toBe("dark");
+      expect(view.getPreference()).toBe("dark");
+      expect(window.localStorage.getItem("ouroboros-theme-preference")).toBe("dark");
+    });
+
+    view.cleanup();
+  });
+});

--- a/apps/web/src/components/theme/app-theme-provider.test.tsx
+++ b/apps/web/src/components/theme/app-theme-provider.test.tsx
@@ -1,7 +1,7 @@
 import { act } from "react";
 import { createRoot } from "react-dom/client";
-import { beforeEach, describe, expect, it, vi } from "vitest";
-import { AppThemeProvider, useThemePreference } from "./app-theme-provider";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { AppThemeProvider, STORAGE_KEY, useThemePreference } from "./app-theme-provider";
 
 declare global {
   // eslint-disable-next-line no-var
@@ -91,6 +91,8 @@ function renderThemeProbe() {
 }
 
 describe("AppThemeProvider", () => {
+  let view: ReturnType<typeof renderThemeProbe> | undefined;
+
   beforeEach(() => {
     vi.unstubAllGlobals();
     globalThis.IS_REACT_ACT_ENVIRONMENT = true;
@@ -98,9 +100,14 @@ describe("AppThemeProvider", () => {
     document.body.innerHTML = "";
   });
 
+  afterEach(() => {
+    view?.cleanup();
+    view = undefined;
+  });
+
   it("follows system preference when no override is stored", async () => {
     const mediaQueryList = installMatchMediaMock(true);
-    const view = renderThemeProbe();
+    view = renderThemeProbe();
 
     expect(view.getPreference()).toBe("system");
     expect(view.getAppearance()).toBe("dark");
@@ -110,16 +117,14 @@ describe("AppThemeProvider", () => {
     });
 
     await vi.waitFor(() => {
-      expect(view.getAppearance()).toBe("light");
+      expect(view!.getAppearance()).toBe("light");
     });
-
-    view.cleanup();
   });
 
   it("uses stored override and persists manual toggle", async () => {
     installMatchMediaMock(true);
-    window.localStorage.setItem("ouroboros-theme-preference", "light");
-    const view = renderThemeProbe();
+    window.localStorage.setItem(STORAGE_KEY, "light");
+    view = renderThemeProbe();
 
     expect(view.getPreference()).toBe("light");
     expect(view.getAppearance()).toBe("light");
@@ -127,11 +132,9 @@ describe("AppThemeProvider", () => {
     view.toggle();
 
     await vi.waitFor(() => {
-      expect(view.getAppearance()).toBe("dark");
-      expect(view.getPreference()).toBe("dark");
-      expect(window.localStorage.getItem("ouroboros-theme-preference")).toBe("dark");
+      expect(view!.getAppearance()).toBe("dark");
+      expect(view!.getPreference()).toBe("dark");
+      expect(window.localStorage.getItem(STORAGE_KEY)).toBe("dark");
     });
-
-    view.cleanup();
   });
 });

--- a/apps/web/src/components/theme/app-theme-provider.tsx
+++ b/apps/web/src/components/theme/app-theme-provider.tsx
@@ -1,0 +1,124 @@
+"use client";
+
+import { Theme } from "@radix-ui/themes";
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+  type ReactNode,
+} from "react";
+
+type ThemePreference = "system" | "light" | "dark";
+type ThemeAppearance = "light" | "dark";
+
+const STORAGE_KEY = "ouroboros-theme-preference";
+const DARK_SCHEME_QUERY = "(prefers-color-scheme: dark)";
+
+type ThemePreferenceContextValue = {
+  appearance: ThemeAppearance;
+  preference: ThemePreference;
+  toggleTheme: () => void;
+  setPreference: (preference: ThemePreference) => void;
+};
+
+const ThemePreferenceContext = createContext<ThemePreferenceContextValue | null>(null);
+
+function isThemePreference(value: string | null): value is ThemePreference {
+  return value === "system" || value === "light" || value === "dark";
+}
+
+function getStoredPreference(): ThemePreference {
+  if (typeof window === "undefined") {
+    return "system";
+  }
+
+  const stored = window.localStorage.getItem(STORAGE_KEY);
+  return isThemePreference(stored) ? stored : "system";
+}
+
+export function resolveAppearance(preference: ThemePreference, prefersDark: boolean): ThemeAppearance {
+  if (preference === "system") {
+    return prefersDark ? "dark" : "light";
+  }
+
+  return preference;
+}
+
+export function AppThemeProvider({ children }: { children: ReactNode }) {
+  const [preference, setPreference] = useState<ThemePreference>(() => getStoredPreference());
+  const [prefersDark, setPrefersDark] = useState<boolean>(() => {
+    if (typeof window === "undefined") {
+      return false;
+    }
+    return window.matchMedia(DARK_SCHEME_QUERY).matches;
+  });
+
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return undefined;
+    }
+
+    const media = window.matchMedia(DARK_SCHEME_QUERY);
+    const onMediaChange = (event: MediaQueryListEvent) => {
+      setPrefersDark(event.matches);
+    };
+
+    setPrefersDark(media.matches);
+    media.addEventListener("change", onMediaChange);
+
+    return () => {
+      media.removeEventListener("change", onMediaChange);
+    };
+  }, []);
+
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    if (preference === "system") {
+      window.localStorage.removeItem(STORAGE_KEY);
+      return;
+    }
+
+    window.localStorage.setItem(STORAGE_KEY, preference);
+  }, [preference]);
+
+  const appearance = resolveAppearance(preference, prefersDark);
+
+  const toggleTheme = useCallback(() => {
+    setPreference((previousPreference) => {
+      const previousAppearance = resolveAppearance(previousPreference, prefersDark);
+      return previousAppearance === "dark" ? "light" : "dark";
+    });
+  }, [prefersDark]);
+
+  const value = useMemo<ThemePreferenceContextValue>(
+    () => ({
+      appearance,
+      preference,
+      toggleTheme,
+      setPreference,
+    }),
+    [appearance, preference, toggleTheme],
+  );
+
+  return (
+    <ThemePreferenceContext.Provider value={value}>
+      <Theme accentColor="iris" grayColor="slate" radius="medium" appearance={appearance}>
+        {children}
+      </Theme>
+    </ThemePreferenceContext.Provider>
+  );
+}
+
+export function useThemePreference() {
+  const context = useContext(ThemePreferenceContext);
+  if (!context) {
+    throw new Error("useThemePreference must be used inside AppThemeProvider");
+  }
+  return context;
+}

--- a/apps/web/src/components/theme/app-theme-provider.tsx
+++ b/apps/web/src/components/theme/app-theme-provider.tsx
@@ -14,7 +14,7 @@ import {
 type ThemePreference = "system" | "light" | "dark";
 type ThemeAppearance = "light" | "dark";
 
-const STORAGE_KEY = "ouroboros-theme-preference";
+export const STORAGE_KEY = "ouroboros-theme-preference";
 const DARK_SCHEME_QUERY = "(prefers-color-scheme: dark)";
 
 type ThemePreferenceContextValue = {
@@ -35,8 +35,12 @@ function getStoredPreference(): ThemePreference {
     return "system";
   }
 
-  const stored = window.localStorage.getItem(STORAGE_KEY);
-  return isThemePreference(stored) ? stored : "system";
+  try {
+    const stored = window.localStorage.getItem(STORAGE_KEY);
+    return isThemePreference(stored) ? stored : "system";
+  } catch {
+    return "system";
+  }
 }
 
 export function resolveAppearance(preference: ThemePreference, prefersDark: boolean): ThemeAppearance {
@@ -79,12 +83,16 @@ export function AppThemeProvider({ children }: { children: ReactNode }) {
       return;
     }
 
-    if (preference === "system") {
-      window.localStorage.removeItem(STORAGE_KEY);
-      return;
-    }
+    try {
+      if (preference === "system") {
+        window.localStorage.removeItem(STORAGE_KEY);
+        return;
+      }
 
-    window.localStorage.setItem(STORAGE_KEY, preference);
+      window.localStorage.setItem(STORAGE_KEY, preference);
+    } catch {
+      // Storage unavailable (e.g. private browsing with storage disabled); skip persistence.
+    }
   }, [preference]);
 
   const appearance = resolveAppearance(preference, prefersDark);

--- a/public/WHATS_NEW.md
+++ b/public/WHATS_NEW.md
@@ -1,0 +1,3 @@
+# What's New
+
+- Added system-aware light/dark mode support with a top-right toggle in the web application header.


### PR DESCRIPTION
## What was done and why
- Replaced the hard-coded dark Radix theme with a client-side `AppThemeProvider` that follows the OS color scheme by default.
- Added a top-right header toggle button so users can manually switch between light and dark modes.
- Added tests for system preference behavior and persisted manual overrides.
- Updated roadmap/notes files to record completion of issue #67.

## How to test
- Run `yarn build` from repo root.
- Run `yarn test` from repo root.
- Start the app (`yarn dev`) and confirm the UI follows system theme when no override is set.
- Click the top-right theme icon and confirm mode switches immediately and remains after reload.

## Risk/notes
- Theme state is persisted in `localStorage` under `ouroboros-theme-preference`.
- Existing Vite deprecation warning in test output is unchanged and pre-existing.

Fixes #67

Made with [Cursor](https://cursor.com)