### PR TITLE
Fix #7 - first-run onboarding wizard

### DIFF
--- a/PLANNED_FEATURE_ROADMAP_2026.md
+++ b/PLANNED_FEATURE_ROADMAP_2026.md
@@ -16,6 +16,7 @@ Legend
 
 Completed
 - #67 - Added system-aware light/dark mode with a top-right header toggle in the web app.
+- #7 - Added a first-run onboarding wizard for workspace setup, initial project connection, and first provider setup.
 
 ---
 
@@ -32,7 +33,6 @@ Completed
 
 | #     | Issue                                                                                          | Tier | Notes                                                    |
 |-------|------------------------------------------------------------------------------------------------|------|----------------------------------------------------------|
-| #7 | First-run onboarding wizard (workspace name → first project → first provider key)              | MVP  | Wraps the `/projects`, `/providers` flows in a guided 3-step modal |
 | #8 | Healthcheck panel: ping each configured provider, surface "needs key" / "ollama unreachable"   | MVP  | New `GET /api/providers/{id}/health` and a `/health` page       |
 | #9 | Auto-detect repo `build`/`test` commands (package.json scripts, pyproject sections, Makefile)  | MVP  | Pre-fills Project commands so first run "just works"             |
 | #10 | Improved router default policy (per-language) baked into seed agents, not just `coder`         | MVP  | Currently only the `coder` agent has language hints              |

--- a/apps/api/ouroboros_api/api/schemas.py
+++ b/apps/api/ouroboros_api/api/schemas.py
@@ -16,7 +16,22 @@ class WorkspaceOut(_Base):
     id: str
     slug: str
     name: str
+    onboarding_completed_at: datetime | None = None
     created_at: datetime
+
+
+class WorkspaceMeOut(_Base):
+    id: str
+    slug: str
+    name: str
+    onboarding_completed_at: datetime | None = None
+    project_count: int
+    provider_count: int
+    requires_onboarding: bool
+
+
+class WorkspaceOnboardingIn(_Base):
+    name: str | None = None
 
 
 class ProjectIn(_Base):

--- a/apps/api/ouroboros_api/api/workspaces.py
+++ b/apps/api/ouroboros_api/api/workspaces.py
@@ -2,18 +2,66 @@
 
 from __future__ import annotations
 
+from datetime import UTC, datetime
+
 from fastapi import APIRouter, Depends
-from sqlalchemy import select
+from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from ..db.models import Workspace
-from .deps import db_session
-from .schemas import WorkspaceOut
+from ..db.models import Project, Provider, Workspace
+from .deps import db_session, workspace
+from .schemas import WorkspaceMeOut, WorkspaceOnboardingIn, WorkspaceOut
 
 router = APIRouter(prefix="/api/workspaces", tags=["workspaces"])
+
+
+async def _workspace_status(session: AsyncSession, ws: Workspace) -> WorkspaceMeOut:
+    project_count = await session.scalar(
+        select(func.count(Project.id)).where(Project.workspace_id == ws.id)
+    )
+    provider_count = await session.scalar(
+        select(func.count(Provider.id)).where(Provider.workspace_id == ws.id)
+    )
+    project_count = int(project_count or 0)
+    provider_count = int(provider_count or 0)
+    requires_onboarding = (
+        ws.onboarding_completed_at is None and (project_count == 0 or provider_count == 0)
+    )
+    return WorkspaceMeOut(
+        id=ws.id,
+        slug=ws.slug,
+        name=ws.name,
+        onboarding_completed_at=ws.onboarding_completed_at,
+        project_count=project_count,
+        provider_count=provider_count,
+        requires_onboarding=requires_onboarding,
+    )
 
 
 @router.get("", response_model=list[WorkspaceOut])
 async def list_workspaces(session: AsyncSession = Depends(db_session)) -> list[WorkspaceOut]:
     res = await session.execute(select(Workspace).order_by(Workspace.created_at))
     return [WorkspaceOut.model_validate(w) for w in res.scalars()]
+
+
+@router.get("/me", response_model=WorkspaceMeOut)
+async def get_workspace_me(
+    ws: Workspace = Depends(workspace),
+    session: AsyncSession = Depends(db_session),
+) -> WorkspaceMeOut:
+    return await _workspace_status(session, ws)
+
+
+@router.post("/me/onboarding", response_model=WorkspaceMeOut)
+async def complete_onboarding(
+    payload: WorkspaceOnboardingIn,
+    ws: Workspace = Depends(workspace),
+    session: AsyncSession = Depends(db_session),
+) -> WorkspaceMeOut:
+    name = payload.name.strip() if payload.name else ""
+    if name:
+        ws.name = name
+    ws.onboarding_completed_at = datetime.now(UTC)
+    await session.commit()
+    await session.refresh(ws)
+    return await _workspace_status(session, ws)

--- a/apps/api/ouroboros_api/db/migrations/versions/0002_workspace_onboarding_completed.py
+++ b/apps/api/ouroboros_api/db/migrations/versions/0002_workspace_onboarding_completed.py
@@ -1,0 +1,25 @@
+"""add workspace onboarding completion timestamp
+
+Revision ID: 0002_workspace_onboarding_completed
+Revises: 0001_initial
+Create Date: 2026-04-19
+
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0002_workspace_onboarding_completed"
+down_revision = "0001_initial"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("workspaces", sa.Column("onboarding_completed_at", sa.DateTime(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("workspaces", "onboarding_completed_at")

--- a/apps/api/ouroboros_api/db/models.py
+++ b/apps/api/ouroboros_api/db/models.py
@@ -42,6 +42,7 @@ class Workspace(Base, TimestampMixin):
     id: Mapped[str] = mapped_column(String(36), primary_key=True, default=_uuid)
     slug: Mapped[str] = mapped_column(String(64), unique=True, nullable=False)
     name: Mapped[str] = mapped_column(String(128), nullable=False)
+    onboarding_completed_at: Mapped[datetime | None] = mapped_column(DateTime)
 
 
 class Project(Base, TimestampMixin):

--- a/apps/api/tests/test_workspaces_api.py
+++ b/apps/api/tests/test_workspaces_api.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from pathlib import Path
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from ouroboros_api.api import deps
+from ouroboros_api.main import create_app
+from ouroboros_api.db.models import Base, Project, Provider, Workspace
+
+
+@pytest_asyncio.fixture
+async def app_and_session(
+    tmp_path: Path,
+) -> AsyncIterator[tuple[object, async_sessionmaker[AsyncSession]]]:
+    db_path = tmp_path / "workspace-test.sqlite"
+    engine = create_async_engine(
+        f"sqlite+aiosqlite:///{db_path}",
+        connect_args={"check_same_thread": False},
+    )
+    session_factory = async_sessionmaker(engine, expire_on_commit=False, class_=AsyncSession)
+
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+    async with session_factory() as session:
+        session.add(Workspace(slug="default", name="Default Workspace"))
+        await session.commit()
+
+    app = create_app()
+
+    async def override_db_session() -> AsyncIterator[AsyncSession]:
+        async with session_factory() as session:
+            yield session
+
+    app.dependency_overrides[deps.db_session] = override_db_session
+    try:
+        yield app, session_factory
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_workspace_me_requires_onboarding_when_empty(
+    app_and_session: tuple[object, async_sessionmaker[AsyncSession]],
+) -> None:
+    app, _ = app_and_session
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        res = await client.get("/api/workspaces/me")
+
+    assert res.status_code == 200
+    payload = res.json()
+    assert payload["project_count"] == 0
+    assert payload["provider_count"] == 0
+    assert payload["requires_onboarding"] is True
+    assert payload["onboarding_completed_at"] is None
+
+
+@pytest.mark.asyncio
+async def test_workspace_me_does_not_require_onboarding_after_minimum_entities_exist(
+    app_and_session: tuple[object, async_sessionmaker[AsyncSession]],
+) -> None:
+    app, session_factory = app_and_session
+    async with session_factory() as session:
+        ws = (await session.execute(select(Workspace).where(Workspace.slug == "default"))).scalar_one()
+        assert ws is not None
+        workspace_id = ws.id
+        session.add(
+            Project(
+                workspace_id=workspace_id,
+                name="Demo",
+                repo_url="https://github.com/acme/demo",
+                scm_kind="github",
+                default_branch="main",
+            )
+        )
+        session.add(Provider(workspace_id=workspace_id, name="Ollama", kind="ollama"))
+        await session.commit()
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        res = await client.get("/api/workspaces/me")
+
+    assert res.status_code == 200
+    payload = res.json()
+    assert payload["project_count"] == 1
+    assert payload["provider_count"] == 1
+    assert payload["requires_onboarding"] is False
+    assert payload["onboarding_completed_at"] is None
+
+
+@pytest.mark.asyncio
+async def test_workspace_onboarding_endpoint_marks_completion_and_updates_name(
+    app_and_session: tuple[object, async_sessionmaker[AsyncSession]],
+) -> None:
+    app, _ = app_and_session
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        res = await client.post(
+            "/api/workspaces/me/onboarding",
+            json={"name": "Team Phoenix"},
+        )
+
+    assert res.status_code == 200
+    payload = res.json()
+    assert payload["name"] == "Team Phoenix"
+    assert payload["requires_onboarding"] is False
+    assert payload["onboarding_completed_at"] is not None

--- a/apps/api/tests/test_workspaces_api.py
+++ b/apps/api/tests/test_workspaces_api.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
 from pathlib import Path
 
 import pytest
@@ -33,6 +34,12 @@ async def app_and_session(
         await session.commit()
 
     app = create_app()
+
+    @asynccontextmanager
+    async def noop_lifespan(app: object) -> AsyncIterator[None]:
+        yield
+
+    app.router.lifespan_context = noop_lifespan  # type: ignore[method-assign]
 
     async def override_db_session() -> AsyncIterator[AsyncSession]:
         async with session_factory() as session:

--- a/apps/api/tests/test_workspaces_api.py
+++ b/apps/api/tests/test_workspaces_api.py
@@ -36,7 +36,7 @@ async def app_and_session(
     app = create_app()
 
     @asynccontextmanager
-    async def noop_lifespan(app: object) -> AsyncIterator[None]:
+    async def noop_lifespan(_app: object) -> AsyncIterator[None]:
         yield
 
     app.router.lifespan_context = noop_lifespan  # type: ignore[method-assign]

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import "./globals.css";
 import type { ReactNode } from "react";
 import { TopHeader } from "@/components/layout/top-header";
+import { OnboardingWizard } from "@/components/onboarding/wizard";
 import { AppThemeProvider } from "@/components/theme/app-theme-provider";
 
 export const metadata = {
@@ -17,6 +18,7 @@ export default function RootLayout({ children }: { children: ReactNode }) {
             <TopHeader />
             <div className="app-body">{children}</div>
           </div>
+          <OnboardingWizard />
         </AppThemeProvider>
       </body>
     </html>

--- a/apps/web/src/components/onboarding/wizard.test.tsx
+++ b/apps/web/src/components/onboarding/wizard.test.tsx
@@ -1,0 +1,173 @@
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { SWRConfig } from "swr";
+import { Theme } from "@radix-ui/themes";
+import { OnboardingWizard } from "./wizard";
+
+declare global {
+  // eslint-disable-next-line no-var
+  var fetch: typeof window.fetch;
+  // eslint-disable-next-line no-var
+  var IS_REACT_ACT_ENVIRONMENT: boolean | undefined;
+}
+
+type FetchCall = { url: string; method: string; body?: unknown };
+
+async function flush() {
+  await act(async () => {
+    await Promise.resolve();
+  });
+}
+
+async function waitForText(container: HTMLElement, text: string, present = true) {
+  for (let attempt = 0; attempt < 20; attempt += 1) {
+    await flush();
+    const hasText = container.textContent?.includes(text) ?? false;
+    if ((present && hasText) || (!present && !hasText)) {
+      return;
+    }
+  }
+  throw new Error(`Timed out waiting for ${present ? "presence" : "absence"} of text: ${text}`);
+}
+
+function renderWizard() {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+
+  act(() => {
+    root.render(
+      <Theme>
+        <SWRConfig value={{ provider: () => new Map() }}>
+          <OnboardingWizard />
+        </SWRConfig>
+      </Theme>,
+    );
+  });
+
+  return {
+    container,
+    unmount: () => {
+      act(() => {
+        root.unmount();
+      });
+      container.remove();
+    },
+  };
+}
+
+describe("OnboardingWizard", () => {
+  let onboardingStatus = {
+    id: "ws-1",
+    slug: "default",
+    name: "Default Workspace",
+    onboarding_completed_at: null,
+    project_count: 0,
+    provider_count: 0,
+    requires_onboarding: true,
+  };
+  const calls: FetchCall[] = [];
+
+  beforeEach(() => {
+    globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+    vi.stubGlobal(
+      "ResizeObserver",
+      class {
+        observe() {}
+        unobserve() {}
+        disconnect() {}
+      },
+    );
+    calls.length = 0;
+    onboardingStatus = {
+      id: "ws-1",
+      slug: "default",
+      name: "Default Workspace",
+      onboarding_completed_at: null,
+      project_count: 0,
+      provider_count: 0,
+      requires_onboarding: true,
+    };
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: string, init?: RequestInit) => {
+        const method = init?.method ?? "GET";
+        const body = init?.body ? JSON.parse(String(init.body)) : undefined;
+        calls.push({ url, method, body });
+
+        if (url === "/api/workspaces/me" && method === "GET") {
+          return new Response(JSON.stringify(onboardingStatus), {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          });
+        }
+        if (url === "/api/projects" && method === "POST") {
+          onboardingStatus.project_count = 1;
+          return new Response(JSON.stringify({ id: "project-1" }), {
+            status: 201,
+            headers: { "content-type": "application/json" },
+          });
+        }
+        if (url === "/api/providers" && method === "POST") {
+          onboardingStatus.provider_count = 1;
+          return new Response(JSON.stringify({ id: "provider-1" }), {
+            status: 201,
+            headers: { "content-type": "application/json" },
+          });
+        }
+        if (url === "/api/workspaces/me/onboarding" && method === "POST") {
+          onboardingStatus = {
+            ...onboardingStatus,
+            name: String(body?.name || onboardingStatus.name),
+            onboarding_completed_at: "2026-04-19T00:00:00Z",
+            requires_onboarding: false,
+          };
+          return new Response(JSON.stringify(onboardingStatus), {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          });
+        }
+        return new Response("Not found", { status: 404 });
+      }) as typeof fetch,
+    );
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = "";
+    vi.unstubAllGlobals();
+  });
+
+  it("can be skipped and resurfaces on a new load", async () => {
+    const view = renderWizard();
+    await waitForText(view.container, "Name your workspace");
+
+    const skipButton = Array.from(view.container.querySelectorAll("button")).find((node) =>
+      node.textContent?.includes("Skip for now"),
+    );
+    expect(skipButton).toBeTruthy();
+    act(() => {
+      (skipButton as HTMLButtonElement).click();
+    });
+    await waitForText(view.container, "Name your workspace", false);
+
+    view.unmount();
+    const second = renderWizard();
+    await waitForText(second.container, "Name your workspace");
+  });
+
+  it("stays hidden when onboarding is already complete", async () => {
+    onboardingStatus = {
+      ...onboardingStatus,
+      onboarding_completed_at: "2026-04-19T00:00:00Z",
+      project_count: 1,
+      provider_count: 1,
+      requires_onboarding: false,
+    };
+    const view = renderWizard();
+    await flush();
+    expect(view.container.textContent || "").not.toContain("Name your workspace");
+    expect(calls.some((call) => call.url === "/api/workspaces/me" && call.method === "GET")).toBe(true);
+  });
+});

--- a/apps/web/src/components/onboarding/wizard.tsx
+++ b/apps/web/src/components/onboarding/wizard.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import type { ReactNode } from "react";
+import * as Dialog from "@radix-ui/react-dialog";
 import { Button, Flex, Select, Text, TextField } from "@radix-ui/themes";
 import { mutate } from "swr";
 import { useWorkspaceOnboarding } from "@/lib/api/hooks";
@@ -46,17 +47,20 @@ export function OnboardingWizard() {
     enabled: true,
   });
 
+  useEffect(() => {
+    if (data?.name && workspaceName === "") {
+      setWorkspaceName(data.name);
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [data?.name]);
+
   if (!data && !isLoading) {
     return null;
   }
 
   const shouldShow = Boolean(data?.requires_onboarding) && !dismissed;
-  if (!shouldShow) {
-    return null;
-  }
 
-  const resolvedWorkspaceName = workspaceName || data?.name || "";
-  const canAdvanceStepOne = resolvedWorkspaceName.trim().length > 0;
+  const canAdvanceStepOne = workspaceName.trim().length > 0;
   const canAdvanceStepTwo = project.name.trim().length > 0 && project.repo_url.trim().length > 0;
   const canAdvanceStepThree =
     provider.name.trim().length > 0 &&
@@ -75,9 +79,6 @@ export function OnboardingWizard() {
     setBusy(true);
     try {
       if (step === 1) {
-        if (!workspaceName) {
-          setWorkspaceName(data.name);
-        }
         setStep(2);
         return;
       }
@@ -99,7 +100,7 @@ export function OnboardingWizard() {
         api_key: provider.api_key?.trim() || undefined,
       });
       await mutate("/api/providers");
-      await api.post("/api/workspaces/me/onboarding", { name: resolvedWorkspaceName.trim() });
+      await api.post("/api/workspaces/me/onboarding", { name: workspaceName.trim() });
       await mutate("/api/workspaces/me");
       setDismissed(true);
     } catch (err) {
@@ -110,12 +111,21 @@ export function OnboardingWizard() {
   };
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4">
-      <div className="w-full max-w-2xl rounded-xl border border-gray-200 bg-white p-6 shadow-2xl">
-        <Flex justify="between" align="center" mb="3">
-          <Text size="5" weight="bold">{stepTitle}</Text>
-          <Button variant="ghost" color="gray" onClick={() => setDismissed(true)}>Skip for now</Button>
-        </Flex>
+    <Dialog.Root open={shouldShow} onOpenChange={(open) => { if (!open) setDismissed(true); }}>
+      <Dialog.Portal>
+        <Dialog.Overlay className="fixed inset-0 z-50 bg-black/40" />
+        <Dialog.Content
+          className="fixed left-1/2 top-1/2 z-50 w-full max-w-2xl -translate-x-1/2 -translate-y-1/2 rounded-xl border border-gray-200 bg-white p-6 shadow-2xl focus:outline-none"
+          aria-describedby={undefined}
+        >
+          <Flex justify="between" align="center" mb="3">
+            <Dialog.Title asChild>
+              <Text size="5" weight="bold">{stepTitle}</Text>
+            </Dialog.Title>
+            <Dialog.Close asChild>
+              <Button variant="ghost" color="gray">Skip for now</Button>
+            </Dialog.Close>
+          </Flex>
         <Text size="2" color="gray">
           Step {step} of 3
         </Text>
@@ -125,7 +135,7 @@ export function OnboardingWizard() {
             <Text size="2" weight="medium">Workspace name</Text>
             <TextField.Root
               placeholder="Acme Engineering"
-              value={resolvedWorkspaceName}
+              value={workspaceName}
               onChange={(event) => setWorkspaceName(event.target.value)}
             />
           </Flex>
@@ -249,8 +259,9 @@ export function OnboardingWizard() {
             {busy ? "Working..." : step === 3 ? "Finish setup" : "Continue"}
           </Button>
         </Flex>
-      </div>
-    </div>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
   );
 }
 

--- a/apps/web/src/components/onboarding/wizard.tsx
+++ b/apps/web/src/components/onboarding/wizard.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import type { ReactNode } from "react";
 import * as Dialog from "@radix-ui/react-dialog";
 import { Button, Flex, Select, Text, TextField } from "@radix-ui/themes";
@@ -47,11 +47,13 @@ export function OnboardingWizard() {
     enabled: true,
   });
 
+  const nameInitialized = useRef(false);
+
   useEffect(() => {
-    if (data?.name && workspaceName === "") {
+    if (data?.name && !nameInitialized.current) {
+      nameInitialized.current = true;
       setWorkspaceName(data.name);
     }
-  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [data?.name]);
 
   if (!data && !isLoading) {

--- a/apps/web/src/components/onboarding/wizard.tsx
+++ b/apps/web/src/components/onboarding/wizard.tsx
@@ -1,0 +1,264 @@
+"use client";
+
+import { useState } from "react";
+import type { ReactNode } from "react";
+import { Button, Flex, Select, Text, TextField } from "@radix-ui/themes";
+import { mutate } from "swr";
+import { useWorkspaceOnboarding } from "@/lib/api/hooks";
+import { api } from "@/lib/api/client";
+import type { ProjectInput, ProviderInput, Provider } from "@/lib/api/types";
+
+type Step = 1 | 2 | 3;
+
+const EMPTY_PROJECT: ProjectInput = {
+  name: "",
+  repo_url: "",
+  scm_kind: "github",
+  default_branch: "main",
+  local_clone_hint: null,
+  default_flow_id: null,
+  build_command: null,
+  test_command: null,
+  config: {},
+};
+
+const DEFAULT_PROVIDER_URL: Record<Provider["kind"], string | null> = {
+  ollama: "http://localhost:11434",
+  anthropic: "https://api.anthropic.com",
+  github_models: "https://models.github.ai",
+  opencode: null,
+  gh_copilot: null,
+};
+
+export function OnboardingWizard() {
+  const { data, isLoading } = useWorkspaceOnboarding();
+  const [step, setStep] = useState<Step>(1);
+  const [dismissed, setDismissed] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [workspaceName, setWorkspaceName] = useState("");
+  const [project, setProject] = useState<ProjectInput>(EMPTY_PROJECT);
+  const [provider, setProvider] = useState<ProviderInput>({
+    name: "Local Ollama",
+    kind: "ollama",
+    base_url: DEFAULT_PROVIDER_URL.ollama,
+    config: {},
+    enabled: true,
+  });
+
+  if (!data && !isLoading) {
+    return null;
+  }
+
+  const shouldShow = Boolean(data?.requires_onboarding) && !dismissed;
+  if (!shouldShow) {
+    return null;
+  }
+
+  const resolvedWorkspaceName = workspaceName || data?.name || "";
+  const canAdvanceStepOne = resolvedWorkspaceName.trim().length > 0;
+  const canAdvanceStepTwo = project.name.trim().length > 0 && project.repo_url.trim().length > 0;
+  const canAdvanceStepThree =
+    provider.name.trim().length > 0 &&
+    (provider.kind !== "anthropic" || Boolean(provider.api_key?.trim()));
+
+  const stepTitle =
+    step === 1 ? "Name your workspace" : step === 2 ? "Connect your first project" : "Connect your first provider";
+
+  const submitStep = async () => {
+    if (!data) return;
+    if (step === 1 && !canAdvanceStepOne) return;
+    if (step === 2 && !canAdvanceStepTwo) return;
+    if (step === 3 && !canAdvanceStepThree) return;
+
+    setError(null);
+    setBusy(true);
+    try {
+      if (step === 1) {
+        if (!workspaceName) {
+          setWorkspaceName(data.name);
+        }
+        setStep(2);
+        return;
+      }
+      if (step === 2) {
+        await api.post("/api/projects", {
+          ...project,
+          name: project.name.trim(),
+          repo_url: project.repo_url.trim(),
+          local_clone_hint: project.local_clone_hint?.trim() || null,
+        });
+        await mutate("/api/projects");
+        setStep(3);
+        return;
+      }
+
+      await api.post("/api/providers", {
+        ...provider,
+        name: provider.name.trim(),
+        api_key: provider.api_key?.trim() || undefined,
+      });
+      await mutate("/api/providers");
+      await api.post("/api/workspaces/me/onboarding", { name: resolvedWorkspaceName.trim() });
+      await mutate("/api/workspaces/me");
+      setDismissed(true);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Something went wrong.");
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4">
+      <div className="w-full max-w-2xl rounded-xl border border-gray-200 bg-white p-6 shadow-2xl">
+        <Flex justify="between" align="center" mb="3">
+          <Text size="5" weight="bold">{stepTitle}</Text>
+          <Button variant="ghost" color="gray" onClick={() => setDismissed(true)}>Skip for now</Button>
+        </Flex>
+        <Text size="2" color="gray">
+          Step {step} of 3
+        </Text>
+
+        {step === 1 ? (
+          <Flex direction="column" gap="2" mt="4">
+            <Text size="2" weight="medium">Workspace name</Text>
+            <TextField.Root
+              placeholder="Acme Engineering"
+              value={resolvedWorkspaceName}
+              onChange={(event) => setWorkspaceName(event.target.value)}
+            />
+          </Flex>
+        ) : null}
+
+        {step === 2 ? (
+          <Flex direction="column" gap="3" mt="4">
+            <Field label="Project name">
+              <TextField.Root
+                value={project.name}
+                onChange={(event) => setProject({ ...project, name: event.target.value })}
+              />
+            </Field>
+            <Field label="Repository URL">
+              <TextField.Root
+                placeholder="https://github.com/org/repo"
+                value={project.repo_url}
+                onChange={(event) => setProject({ ...project, repo_url: event.target.value })}
+              />
+            </Field>
+            <Flex gap="3">
+              <Field label="SCM">
+                <Select.Root
+                  value={project.scm_kind}
+                  onValueChange={(value) =>
+                    setProject({ ...project, scm_kind: value as "github" | "gitlab" })
+                  }
+                >
+                  <Select.Trigger />
+                  <Select.Content>
+                    <Select.Item value="github">GitHub</Select.Item>
+                    <Select.Item value="gitlab">GitLab</Select.Item>
+                  </Select.Content>
+                </Select.Root>
+              </Field>
+              <Field label="Default branch">
+                <TextField.Root
+                  value={project.default_branch}
+                  onChange={(event) =>
+                    setProject({ ...project, default_branch: event.target.value || "main" })
+                  }
+                />
+              </Field>
+            </Flex>
+          </Flex>
+        ) : null}
+
+        {step === 3 ? (
+          <Flex direction="column" gap="3" mt="4">
+            <Field label="Provider kind">
+              <Select.Root
+                value={provider.kind}
+                onValueChange={(value) => {
+                  const kind = value as "ollama" | "anthropic";
+                  setProvider({
+                    ...provider,
+                    kind,
+                    base_url: DEFAULT_PROVIDER_URL[kind],
+                    name: kind === "ollama" ? "Local Ollama" : "Anthropic",
+                  });
+                }}
+              >
+                <Select.Trigger />
+                <Select.Content>
+                  <Select.Item value="ollama">ollama</Select.Item>
+                  <Select.Item value="anthropic">anthropic</Select.Item>
+                </Select.Content>
+              </Select.Root>
+            </Field>
+            <Field label="Provider name">
+              <TextField.Root
+                value={provider.name}
+                onChange={(event) => setProvider({ ...provider, name: event.target.value })}
+              />
+            </Field>
+            <Field label="Base URL">
+              <TextField.Root
+                value={provider.base_url || ""}
+                onChange={(event) =>
+                  setProvider({ ...provider, base_url: event.target.value.trim() || null })
+                }
+              />
+            </Field>
+            {provider.kind === "anthropic" ? (
+              <Field label="Anthropic API key">
+                <TextField.Root
+                  type="password"
+                  placeholder="sk-ant-..."
+                  value={provider.api_key || ""}
+                  onChange={(event) => setProvider({ ...provider, api_key: event.target.value })}
+                />
+              </Field>
+            ) : null}
+          </Flex>
+        ) : null}
+
+        {error ? (
+          <Text size="2" color="red" mt="3">
+            {error}
+          </Text>
+        ) : null}
+
+        <Flex mt="5" justify="between">
+          <Button
+            variant="soft"
+            color="gray"
+            disabled={busy || step === 1}
+            onClick={() => setStep((prev) => (prev > 1 ? ((prev - 1) as Step) : prev))}
+          >
+            Back
+          </Button>
+          <Button
+            onClick={submitStep}
+            disabled={
+              busy ||
+              (step === 1 && !canAdvanceStepOne) ||
+              (step === 2 && !canAdvanceStepTwo) ||
+              (step === 3 && !canAdvanceStepThree)
+            }
+          >
+            {busy ? "Working..." : step === 3 ? "Finish setup" : "Continue"}
+          </Button>
+        </Flex>
+      </div>
+    </div>
+  );
+}
+
+function Field({ label, children }: { label: string; children: ReactNode }) {
+  return (
+    <Flex direction="column" gap="1" style={{ flex: 1 }}>
+      <Text size="2" color="gray" weight="medium">{label}</Text>
+      {children}
+    </Flex>
+  );
+}

--- a/apps/web/src/lib/api/hooks.ts
+++ b/apps/web/src/lib/api/hooks.ts
@@ -14,11 +14,14 @@ import type {
   RoadmapEntry,
   Run,
   RunDetail,
+  WorkspaceOnboardingStatus,
 } from "./types";
 
 const fetcher = <T,>(path: string) => api.get<T>(path);
 
 export const useProjects = () => useSWR<Project[]>("/api/projects", fetcher);
+export const useWorkspaceOnboarding = () =>
+  useSWR<WorkspaceOnboardingStatus>("/api/workspaces/me", fetcher);
 export const useProject = (id: string | null) => useSWR<Project>(id ? `/api/projects/${id}` : null, fetcher);
 export const useIssues = (projectId: string | null, state = "open") =>
   useSWR<Issue[]>(projectId ? `/api/projects/${projectId}/issues?state=${state}` : null, fetcher);

--- a/apps/web/src/lib/api/types.ts
+++ b/apps/web/src/lib/api/types.ts
@@ -1,6 +1,22 @@
 // Type mirrors of the FastAPI Pydantic schemas. Kept handwritten so we don't need codegen at boot.
 
-export type Workspace = { id: string; slug: string; name: string; created_at: string };
+export type Workspace = {
+  id: string;
+  slug: string;
+  name: string;
+  onboarding_completed_at: string | null;
+  created_at: string;
+};
+
+export type WorkspaceOnboardingStatus = {
+  id: string;
+  slug: string;
+  name: string;
+  onboarding_completed_at: string | null;
+  project_count: number;
+  provider_count: number;
+  requires_onboarding: boolean;
+};
 
 export type Project = {
   id: string;

--- a/public/WHATS_NEW.md
+++ b/public/WHATS_NEW.md
@@ -1,3 +1,4 @@
 # What's New
 
 - Added system-aware light/dark mode support with a top-right toggle in the web application header.
+- Added a first-run onboarding wizard and workspace onboarding status APIs to guide setup through workspace naming, first project creation, and first provider connection.


### PR DESCRIPTION
## Summary
- add workspace onboarding persistence in the API by introducing `onboarding_completed_at`, `GET /api/workspaces/me`, and `POST /api/workspaces/me/onboarding`
- add a three-step onboarding wizard rendered from the app layout that guides workspace naming, first project creation, and first provider connection using existing endpoints
- add API and web tests for onboarding status behavior, and update roadmap/changelog entries for ticket completion

## Test plan
- [x] `yarn workspace @ouroboros/api test`
- [x] `yarn workspace ouroboros-web test`
- [x] `yarn build`
- [x] `yarn test`

## Risk/notes
- wizard completion state currently depends on `requires_onboarding` from `/api/workspaces/me`; if existing workspaces rely on older schemas, run migrations before launching
- Next.js build emits an existing warning about `experimental.typedRoutes` config placement; no functional impact from this ticket

Closes #7

Made with [Cursor](https://cursor.com)