### PR TITLE
Fix #8 - add provider healthcheck panel

### DIFF
--- a/apps/api/ouroboros_api/api/providers.py
+++ b/apps/api/ouroboros_api/api/providers.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from datetime import UTC, datetime
 
+import httpx
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy import select
 from sqlalchemy.dialects.sqlite import insert as sqlite_insert
@@ -17,6 +18,7 @@ from .deps import db_session, workspace
 from .schemas import (
     ProviderChatRequest,
     ProviderChatResponse,
+    ProviderHealthOut,
     ProviderIn,
     ProviderModelOut,
     ProviderOut,
@@ -35,6 +37,9 @@ def _to_out(p: Provider) -> ProviderOut:
         has_api_key=bool(p.api_key_secret_ref),
         config=p.config,
         enabled=p.enabled,
+        last_health_status=p.last_health_status,
+        last_health_error=p.last_health_error,
+        last_health_checked_at=p.last_health_checked_at,
     )
 
 
@@ -52,6 +57,84 @@ def _resolve_model(p: Provider, model_id: str | None = None) -> ResolvedModel:
         api_key=api_key,
         extra=dict(p.config or {}),
     )
+
+
+def _error_text(response: httpx.Response) -> str:
+    text = response.text.strip()
+    if text:
+        return text[:1000]
+    return f"{response.status_code} {response.reason_phrase}"
+
+
+def _status_from_http_error(exc: Exception) -> str:
+    if isinstance(exc, httpx.HTTPStatusError):
+        if exc.response.status_code in {401, 403}:
+            return "unauthorized"
+        return "unreachable"
+    if isinstance(exc, httpx.RequestError):
+        return "unreachable"
+    return "unreachable"
+
+
+async def _probe_health(provider: Provider) -> tuple[str, str | None]:
+    resolved = _resolve_model(provider)
+    try:
+        if provider.kind == "ollama":
+            base_url = (provider.base_url or "http://localhost:11434").rstrip("/")
+            async with httpx.AsyncClient(base_url=base_url, timeout=10.0) as client:
+                res = await client.get("/api/tags")
+                res.raise_for_status()
+                models = (res.json() or {}).get("models", [])
+                if not models:
+                    return "no-models", "No models returned by /api/tags"
+                return "ok", None
+
+        if provider.kind == "anthropic":
+            base_url = (provider.base_url or "https://api.anthropic.com").rstrip("/")
+            headers = {
+                "x-api-key": resolved.api_key or "",
+                "anthropic-version": "2023-06-01",
+            }
+            async with httpx.AsyncClient(base_url=base_url, headers=headers, timeout=10.0) as client:
+                res = await client.head("/v1/messages")
+                if res.status_code in {401, 403}:
+                    return "unauthorized", _error_text(res)
+                if res.status_code >= 400 and res.status_code != 405:
+                    return "unreachable", _error_text(res)
+                return "ok", None
+
+        if provider.kind == "github_models":
+            base_url = (provider.base_url or "https://models.github.ai").rstrip("/")
+            headers = {
+                "Authorization": f"Bearer {resolved.api_key or ''}",
+                "Accept": "application/json",
+            }
+            async with httpx.AsyncClient(base_url=base_url, headers=headers, timeout=10.0) as client:
+                res = await client.get("/catalog/models")
+                if res.status_code in {401, 403}:
+                    return "unauthorized", _error_text(res)
+                res.raise_for_status()
+                models = res.json() or []
+                if not models:
+                    return "no-models", "No models returned by /catalog/models"
+                return "ok", None
+
+    except Exception as exc:
+        status = _status_from_http_error(exc)
+        if isinstance(exc, httpx.HTTPStatusError):
+            return status, _error_text(exc.response)
+        return status, str(exc)
+
+    return "ok", None
+
+
+async def _run_health_probe(provider: Provider) -> ProviderHealthOut:
+    status, error = await _probe_health(provider)
+    checked_at = datetime.now(UTC)
+    provider.last_health_status = status
+    provider.last_health_error = error
+    provider.last_health_checked_at = checked_at
+    return ProviderHealthOut(provider_id=provider.id, status=status, error=error, checked_at=checked_at)
 
 
 @router.get("", response_model=list[ProviderOut])
@@ -86,6 +169,7 @@ async def create_provider(
         ref = _secret_ref(ws.id, provider.id)
         secrets.set(ref, payload.api_key)
         provider.api_key_secret_ref = ref
+    await _run_health_probe(provider)
     await session.commit()
     await session.refresh(provider)
     return _to_out(provider)
@@ -122,6 +206,7 @@ async def update_provider(
         ref = provider.api_key_secret_ref or _secret_ref(ws.id, provider.id)
         secrets.set(ref, payload.api_key)
         provider.api_key_secret_ref = ref
+    await _run_health_probe(provider)
     await session.commit()
     await session.refresh(provider)
     return _to_out(provider)
@@ -155,6 +240,20 @@ async def list_models(
         select(ProviderModel).where(ProviderModel.provider_id == provider.id).order_by(ProviderModel.model_id)
     )
     return [ProviderModelOut.model_validate(m) for m in res.scalars()]
+
+
+@router.get("/{provider_id}/health", response_model=ProviderHealthOut)
+async def provider_health(
+    provider_id: str,
+    ws: Workspace = Depends(workspace),
+    session: AsyncSession = Depends(db_session),
+) -> ProviderHealthOut:
+    provider = await session.get(Provider, provider_id)
+    if not provider or provider.workspace_id != ws.id:
+        raise HTTPException(404, "Provider not found")
+    result = await _run_health_probe(provider)
+    await session.commit()
+    return result
 
 
 @router.post("/{provider_id}/models/refresh", response_model=list[ProviderModelOut])

--- a/apps/api/ouroboros_api/api/providers.py
+++ b/apps/api/ouroboros_api/api/providers.py
@@ -125,7 +125,7 @@ async def _probe_health(provider: Provider) -> tuple[str, str | None]:
             return status, _error_text(exc.response)
         return status, str(exc)
 
-    return "ok", None
+    return "unsupported", f"Health probe not implemented for provider kind: {provider.kind}"
 
 
 async def _run_health_probe(provider: Provider) -> ProviderHealthOut:

--- a/apps/api/ouroboros_api/api/schemas.py
+++ b/apps/api/ouroboros_api/api/schemas.py
@@ -107,6 +107,16 @@ class ProviderOut(_Base):
     has_api_key: bool = False
     config: dict[str, Any] = Field(default_factory=dict)
     enabled: bool
+    last_health_status: str | None = None
+    last_health_error: str | None = None
+    last_health_checked_at: datetime | None = None
+
+
+class ProviderHealthOut(_Base):
+    provider_id: str
+    status: str
+    error: str | None = None
+    checked_at: datetime
 
 
 class ProviderModelOut(_Base):

--- a/apps/api/ouroboros_api/db/migrations/versions/0003_provider_health_state.py
+++ b/apps/api/ouroboros_api/db/migrations/versions/0003_provider_health_state.py
@@ -1,0 +1,29 @@
+"""add provider health status columns
+
+Revision ID: 0003_provider_health_state
+Revises: 0002_workspace_onboarding_completed
+Create Date: 2026-04-19
+
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0003_provider_health_state"
+down_revision = "0002_workspace_onboarding_completed"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("providers", sa.Column("last_health_status", sa.String(length=32), nullable=True))
+    op.add_column("providers", sa.Column("last_health_error", sa.Text(), nullable=True))
+    op.add_column("providers", sa.Column("last_health_checked_at", sa.DateTime(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("providers", "last_health_checked_at")
+    op.drop_column("providers", "last_health_error")
+    op.drop_column("providers", "last_health_status")

--- a/apps/api/ouroboros_api/db/models.py
+++ b/apps/api/ouroboros_api/db/models.py
@@ -120,6 +120,9 @@ class Provider(Base, TimestampMixin):
     api_key_secret_ref: Mapped[str | None] = mapped_column(String(200))
     config: Mapped[dict[str, Any]] = mapped_column(JSON, default=dict)
     enabled: Mapped[bool] = mapped_column(Boolean, default=True, nullable=False)
+    last_health_status: Mapped[str | None] = mapped_column(String(32))
+    last_health_error: Mapped[str | None] = mapped_column(Text)
+    last_health_checked_at: Mapped[datetime | None] = mapped_column(DateTime)
 
     models: Mapped[list[ProviderModel]] = relationship(
         back_populates="provider", cascade="all, delete-orphan"

--- a/apps/api/tests/test_providers_api.py
+++ b/apps/api/tests/test_providers_api.py
@@ -1,0 +1,171 @@
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from pathlib import Path
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from ouroboros_api.api import deps
+from ouroboros_api.api import providers as providers_api
+from ouroboros_api.db.models import Base, Provider, Workspace
+from ouroboros_api.main import create_app
+
+
+@pytest_asyncio.fixture
+async def app_and_session(
+    tmp_path: Path,
+) -> AsyncIterator[tuple[object, async_sessionmaker[AsyncSession]]]:
+    db_path = tmp_path / "provider-test.sqlite"
+    engine = create_async_engine(
+        f"sqlite+aiosqlite:///{db_path}",
+        connect_args={"check_same_thread": False},
+    )
+    session_factory = async_sessionmaker(engine, expire_on_commit=False, class_=AsyncSession)
+
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+    async with session_factory() as session:
+        session.add(Workspace(slug="default", name="Default Workspace"))
+        await session.commit()
+
+    app = create_app()
+
+    @asynccontextmanager
+    async def noop_lifespan(_app: object) -> AsyncIterator[None]:
+        yield
+
+    app.router.lifespan_context = noop_lifespan  # type: ignore[method-assign]
+
+    async def override_db_session() -> AsyncIterator[AsyncSession]:
+        async with session_factory() as session:
+            yield session
+
+    app.dependency_overrides[deps.db_session] = override_db_session
+    try:
+        yield app, session_factory
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_create_provider_runs_health_probe_and_persists_result(
+    app_and_session: tuple[object, async_sessionmaker[AsyncSession]],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    app, session_factory = app_and_session
+
+    async def fake_probe(_provider: Provider) -> tuple[str, str | None]:
+        return "unauthorized", "invalid x-api-key"
+
+    monkeypatch.setattr(providers_api, "_probe_health", fake_probe)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        res = await client.post(
+            "/api/providers",
+            json={
+                "name": "Anthropic",
+                "kind": "anthropic",
+                "base_url": "https://api.anthropic.com",
+                "api_key": "bad-key",
+                "config": {},
+                "enabled": True,
+            },
+        )
+
+    assert res.status_code == 201
+    payload = res.json()
+    assert payload["last_health_status"] == "unauthorized"
+    assert payload["last_health_error"] == "invalid x-api-key"
+    assert payload["last_health_checked_at"] is not None
+
+    async with session_factory() as session:
+        provider = await session.get(Provider, payload["id"])
+        assert provider is not None
+        assert provider.last_health_status == "unauthorized"
+        assert provider.last_health_error == "invalid x-api-key"
+        assert provider.last_health_checked_at is not None
+
+
+@pytest.mark.asyncio
+async def test_provider_health_endpoint_updates_persisted_result(
+    app_and_session: tuple[object, async_sessionmaker[AsyncSession]],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    app, session_factory = app_and_session
+    async with session_factory() as session:
+        ws = (await session.execute(select(Workspace).where(Workspace.slug == "default"))).scalar_one()
+        provider = Provider(
+            workspace_id=ws.id,
+            name="Ollama",
+            kind="ollama",
+            base_url="http://localhost:11434",
+        )
+        session.add(provider)
+        await session.commit()
+        provider_id = provider.id
+
+    async def fake_probe(_provider: Provider) -> tuple[str, str | None]:
+        return "unreachable", "connection refused"
+
+    monkeypatch.setattr(providers_api, "_probe_health", fake_probe)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        res = await client.get(f"/api/providers/{provider_id}/health")
+
+    assert res.status_code == 200
+    payload = res.json()
+    assert payload["provider_id"] == provider_id
+    assert payload["status"] == "unreachable"
+    assert payload["error"] == "connection refused"
+    assert payload["checked_at"] is not None
+
+    async with session_factory() as session:
+        provider = await session.get(Provider, provider_id)
+        assert provider is not None
+        assert provider.last_health_status == "unreachable"
+        assert provider.last_health_error == "connection refused"
+        assert provider.last_health_checked_at is not None
+
+
+@pytest.mark.asyncio
+async def test_probe_health_marks_anthropic_401_as_unauthorized(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class FakeResponse:
+        status_code = 401
+        reason_phrase = "Unauthorized"
+        text = '{"error":"invalid x-api-key"}'
+
+    class FakeClient:
+        async def __aenter__(self) -> FakeClient:
+            return self
+
+        async def __aexit__(self, *_: object) -> None:
+            return None
+
+        async def head(self, _path: str) -> FakeResponse:
+            return FakeResponse()
+
+    monkeypatch.setattr(providers_api.httpx, "AsyncClient", lambda **_: FakeClient())
+
+    provider = Provider(
+        id="provider-id",
+        workspace_id="workspace-id",
+        name="Anthropic",
+        kind="anthropic",
+        base_url="https://api.anthropic.com",
+        config={},
+        enabled=True,
+    )
+    status, error = await providers_api._probe_health(provider)
+
+    assert status == "unauthorized"
+    assert error is not None
+    assert "invalid x-api-key" in error

--- a/apps/web/next-env.d.ts
+++ b/apps/web/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/apps/web/src/app/health/page.tsx
+++ b/apps/web/src/app/health/page.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import { Badge, Box, Flex, Text } from "@radix-ui/themes";
+import { CheckCircle2 } from "lucide-react";
+import { PageHeader } from "@/components/layout/page-shell";
+import { useProviders } from "@/lib/api/hooks";
+import type { Provider } from "@/lib/api/types";
+
+const HEALTH_LABEL: Record<NonNullable<Provider["last_health_status"]>, string> = {
+  ok: "ok",
+  unreachable: "unreachable",
+  unauthorized: "unauthorized",
+  "no-models": "no models",
+};
+
+const HEALTH_COLOR: Record<NonNullable<Provider["last_health_status"]>, "green" | "red" | "orange" | "gray"> = {
+  ok: "green",
+  unreachable: "red",
+  unauthorized: "orange",
+  "no-models": "gray",
+};
+
+export default function ProviderHealthPage() {
+  const { data: providers = [] } = useProviders();
+  const allGreen = providers.length > 0 && providers.every((provider) => provider.last_health_status === "ok");
+
+  return (
+    <main className="app-main">
+      <PageHeader
+        title="Provider health"
+        subtitle="Latest probe results for every configured provider"
+        actions={
+          allGreen ? (
+            <Flex align="center" gap="2">
+              <CheckCircle2 size={16} color="var(--green-10)" />
+              <Text size="2" color="green">All providers healthy</Text>
+            </Flex>
+          ) : null
+        }
+      />
+      <Flex direction="column" gap="3">
+        {providers.map((provider) => (
+          <Box key={provider.id} style={{ border: "1px solid var(--gray-a5)", borderRadius: 10, padding: 12 }}>
+            <Flex align="center" justify="between" gap="3">
+              <Flex direction="column" gap="1">
+                <Text size="3" weight="medium">{provider.name}</Text>
+                <Text size="1" color="gray">{provider.kind}</Text>
+              </Flex>
+              <HealthBadge provider={provider} />
+            </Flex>
+            {provider.last_health_error ? (
+              <Text size="1" color="gray" style={{ marginTop: 8, display: "block" }}>
+                {provider.last_health_error}
+              </Text>
+            ) : null}
+          </Box>
+        ))}
+        {providers.length === 0 ? (
+          <Text size="2" color="gray">No providers configured yet.</Text>
+        ) : null}
+      </Flex>
+    </main>
+  );
+}
+
+function HealthBadge({ provider }: { provider: Provider }) {
+  const status = provider.last_health_status;
+  if (!status) {
+    return <Badge color="gray">unknown</Badge>;
+  }
+
+  return (
+    <Badge color={HEALTH_COLOR[status]} title={provider.last_health_error || ""}>
+      {HEALTH_LABEL[status]}
+    </Badge>
+  );
+}

--- a/apps/web/src/app/health/page.tsx
+++ b/apps/web/src/app/health/page.tsx
@@ -1,24 +1,10 @@
 "use client";
 
-import { Badge, Box, Flex, Text } from "@radix-ui/themes";
+import { Box, Flex, Text } from "@radix-ui/themes";
 import { CheckCircle2 } from "lucide-react";
 import { PageHeader } from "@/components/layout/page-shell";
+import { HealthBadge } from "@/components/provider-health-badge";
 import { useProviders } from "@/lib/api/hooks";
-import type { Provider } from "@/lib/api/types";
-
-const HEALTH_LABEL: Record<NonNullable<Provider["last_health_status"]>, string> = {
-  ok: "ok",
-  unreachable: "unreachable",
-  unauthorized: "unauthorized",
-  "no-models": "no models",
-};
-
-const HEALTH_COLOR: Record<NonNullable<Provider["last_health_status"]>, "green" | "red" | "orange" | "gray"> = {
-  ok: "green",
-  unreachable: "red",
-  unauthorized: "orange",
-  "no-models": "gray",
-};
 
 export default function ProviderHealthPage() {
   const { data: providers = [] } = useProviders();
@@ -60,18 +46,5 @@ export default function ProviderHealthPage() {
         ) : null}
       </Flex>
     </main>
-  );
-}
-
-function HealthBadge({ provider }: { provider: Provider }) {
-  const status = provider.last_health_status;
-  if (!status) {
-    return <Badge color="gray">unknown</Badge>;
-  }
-
-  return (
-    <Badge color={HEALTH_COLOR[status]} title={provider.last_health_error || ""}>
-      {HEALTH_LABEL[status]}
-    </Badge>
   );
 }

--- a/apps/web/src/app/providers/page.tsx
+++ b/apps/web/src/app/providers/page.tsx
@@ -3,7 +3,6 @@
 import { useEffect, useState } from "react";
 import { mutate } from "swr";
 import {
-  Badge,
   Box,
   Button,
   Flex,
@@ -13,6 +12,7 @@ import {
 } from "@radix-ui/themes";
 import { PageShell, PageHeader } from "@/components/layout/page-shell";
 import { SidebarList } from "@/components/common/sidebar-list";
+import { HealthBadge } from "@/components/provider-health-badge";
 import { useProviderModels, useProviders } from "@/lib/api/hooks";
 import { api } from "@/lib/api/client";
 import type { Provider, ProviderHealth, ProviderInput } from "@/lib/api/types";
@@ -23,20 +23,6 @@ const DEFAULT_BASE_URL: Record<string, string> = {
   ollama: "http://localhost:11434",
   anthropic: "https://api.anthropic.com",
   github_models: "https://models.github.ai",
-};
-
-const HEALTH_LABEL: Record<NonNullable<Provider["last_health_status"]>, string> = {
-  ok: "ok",
-  unreachable: "unreachable",
-  unauthorized: "unauthorized",
-  "no-models": "no models",
-};
-
-const HEALTH_COLOR: Record<NonNullable<Provider["last_health_status"]>, "green" | "red" | "orange" | "gray"> = {
-  ok: "green",
-  unreachable: "red",
-  unauthorized: "orange",
-  "no-models": "gray",
 };
 
 export default function ProvidersPage() {
@@ -58,10 +44,13 @@ export default function ProvidersPage() {
         config: active.config,
         enabled: active.enabled,
       });
-      setHealthInfo(active.last_health_error);
       setShowHealthDetails(false);
     }
   }, [active?.id]);
+
+  useEffect(() => {
+    setHealthInfo(active?.last_health_error ?? null);
+  }, [active?.last_health_error]);
 
   const startNew = () => {
     setActiveId(null);
@@ -216,31 +205,6 @@ export default function ProvidersPage() {
         <div className="empty-state">Select or create a provider</div>
       )}
     </PageShell>
-  );
-}
-
-function HealthBadge({ provider, onClick }: { provider: Provider; onClick?: () => void }) {
-  const status = provider.last_health_status;
-  const badge = !status ? (
-    <Badge color="gray" title="No health check yet">
-      unknown
-    </Badge>
-  ) : (
-    <Badge color={HEALTH_COLOR[status]} title={provider.last_health_error || ""}>
-      {HEALTH_LABEL[status]}
-    </Badge>
-  );
-
-  if (!onClick) return badge;
-
-  return (
-    <button
-      type="button"
-      onClick={onClick}
-      style={{ background: "transparent", border: 0, padding: 0, margin: 0, cursor: "pointer" }}
-    >
-      {badge}
-    </button>
   );
 }
 

--- a/apps/web/src/app/providers/page.tsx
+++ b/apps/web/src/app/providers/page.tsx
@@ -15,7 +15,7 @@ import { PageShell, PageHeader } from "@/components/layout/page-shell";
 import { SidebarList } from "@/components/common/sidebar-list";
 import { useProviderModels, useProviders } from "@/lib/api/hooks";
 import { api } from "@/lib/api/client";
-import type { Provider, ProviderInput } from "@/lib/api/types";
+import type { Provider, ProviderHealth, ProviderInput } from "@/lib/api/types";
 
 const KINDS: Array<Provider["kind"]> = ["ollama", "anthropic", "github_models", "opencode", "gh_copilot"];
 
@@ -25,10 +25,27 @@ const DEFAULT_BASE_URL: Record<string, string> = {
   github_models: "https://models.github.ai",
 };
 
+const HEALTH_LABEL: Record<NonNullable<Provider["last_health_status"]>, string> = {
+  ok: "ok",
+  unreachable: "unreachable",
+  unauthorized: "unauthorized",
+  "no-models": "no models",
+};
+
+const HEALTH_COLOR: Record<NonNullable<Provider["last_health_status"]>, "green" | "red" | "orange" | "gray"> = {
+  ok: "green",
+  unreachable: "red",
+  unauthorized: "orange",
+  "no-models": "gray",
+};
+
 export default function ProvidersPage() {
   const { data: providers = [] } = useProviders();
   const [activeId, setActiveId] = useState<string | null>(null);
   const [draft, setDraft] = useState<ProviderInput | null>(null);
+  const [healthInfo, setHealthInfo] = useState<string | null>(null);
+  const [showHealthDetails, setShowHealthDetails] = useState(false);
+  const [refreshingHealth, setRefreshingHealth] = useState(false);
 
   const active = activeId ? providers.find((p) => p.id === activeId) ?? null : null;
 
@@ -41,6 +58,8 @@ export default function ProvidersPage() {
         config: active.config,
         enabled: active.enabled,
       });
+      setHealthInfo(active.last_health_error);
+      setShowHealthDetails(false);
     }
   }, [active?.id]);
 
@@ -74,6 +93,19 @@ export default function ProvidersPage() {
     await mutate("/api/providers");
   };
 
+  const refreshHealth = async () => {
+    if (!active) return;
+    setRefreshingHealth(true);
+    try {
+      const res = await api.get<ProviderHealth>(`/api/providers/${active.id}/health`);
+      setHealthInfo(res.error);
+      setShowHealthDetails(false);
+      await mutate("/api/providers");
+    } finally {
+      setRefreshingHealth(false);
+    }
+  };
+
   return (
     <PageShell
       sidebar={
@@ -83,7 +115,7 @@ export default function ProvidersPage() {
             id: p.id,
             primary: p.name,
             secondary: p.kind,
-            badge: p.enabled ? <Badge color="green">on</Badge> : <Badge color="gray">off</Badge>,
+            badge: <HealthBadge provider={p} />,
           }))}
           activeId={activeId}
           onSelect={setActiveId}
@@ -97,6 +129,11 @@ export default function ProvidersPage() {
         actions={
           draft ? (
             <Flex gap="2">
+              {active ? (
+                <Button variant="soft" onClick={refreshHealth} disabled={refreshingHealth}>
+                  {refreshingHealth ? "Refreshing..." : "Refresh health"}
+                </Button>
+              ) : null}
               {active ? (
                 <Button color="red" variant="soft" onClick={remove}>Delete</Button>
               ) : null}
@@ -152,6 +189,18 @@ export default function ProvidersPage() {
                 />
                 <Text size="2">Enabled</Text>
               </Flex>
+              {active ? (
+                <Field label="Health">
+                  <Flex direction="column" gap="1">
+                    <HealthBadge provider={active} onClick={() => setShowHealthDetails((v) => !v)} />
+                    {showHealthDetails ? (
+                      <Box style={{ border: "1px solid var(--gray-a6)", borderRadius: 8, padding: 8 }}>
+                        <Text size="1">{healthInfo || "No error reported by the last health probe."}</Text>
+                      </Box>
+                    ) : null}
+                  </Flex>
+                </Field>
+              ) : null}
               {active && ["ollama", "anthropic", "github_models"].includes(active.kind) ? (
                 <ProviderModelsPanel providerId={active.id} />
               ) : null}
@@ -167,6 +216,31 @@ export default function ProvidersPage() {
         <div className="empty-state">Select or create a provider</div>
       )}
     </PageShell>
+  );
+}
+
+function HealthBadge({ provider, onClick }: { provider: Provider; onClick?: () => void }) {
+  const status = provider.last_health_status;
+  const badge = !status ? (
+    <Badge color="gray" title="No health check yet">
+      unknown
+    </Badge>
+  ) : (
+    <Badge color={HEALTH_COLOR[status]} title={provider.last_health_error || ""}>
+      {HEALTH_LABEL[status]}
+    </Badge>
+  );
+
+  if (!onClick) return badge;
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      style={{ background: "transparent", border: 0, padding: 0, margin: 0, cursor: "pointer" }}
+    >
+      {badge}
+    </button>
   );
 }
 

--- a/apps/web/src/components/layout/top-header.tsx
+++ b/apps/web/src/components/layout/top-header.tsx
@@ -12,6 +12,7 @@ import {
   Boxes,
   Workflow,
   Infinity as InfinityIcon,
+  HeartPulse,
   Moon,
   Sun,
 } from "lucide-react";
@@ -23,6 +24,7 @@ const NAV: Array<{ href: string; label: string; Icon: typeof FolderTree }> = [
   { href: "/runs", label: "Runs", Icon: Activity },
   { href: "/agents", label: "Agents", Icon: Bot },
   { href: "/providers", label: "Providers", Icon: Plug },
+  { href: "/health", label: "Health", Icon: HeartPulse },
   { href: "/mcp", label: "MCP", Icon: Boxes },
   { href: "/routing", label: "Routing", Icon: Workflow },
 ];

--- a/apps/web/src/components/provider-health-badge.tsx
+++ b/apps/web/src/components/provider-health-badge.tsx
@@ -1,0 +1,46 @@
+import { Badge } from "@radix-ui/themes";
+import type { Provider } from "@/lib/api/types";
+
+export const HEALTH_LABEL: Record<NonNullable<Provider["last_health_status"]>, string> = {
+  ok: "ok",
+  unreachable: "unreachable",
+  unauthorized: "unauthorized",
+  "no-models": "no models",
+  unsupported: "unsupported",
+};
+
+export const HEALTH_COLOR: Record<
+  NonNullable<Provider["last_health_status"]>,
+  "green" | "red" | "orange" | "gray"
+> = {
+  ok: "green",
+  unreachable: "red",
+  unauthorized: "orange",
+  "no-models": "gray",
+  unsupported: "gray",
+};
+
+export function HealthBadge({ provider, onClick }: { provider: Provider; onClick?: () => void }) {
+  const status = provider.last_health_status;
+  const badge = !status ? (
+    <Badge color="gray" title="No health check yet">
+      unknown
+    </Badge>
+  ) : (
+    <Badge color={HEALTH_COLOR[status]} title={provider.last_health_error || ""}>
+      {HEALTH_LABEL[status]}
+    </Badge>
+  );
+
+  if (!onClick) return badge;
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      style={{ background: "transparent", border: 0, padding: 0, margin: 0, cursor: "pointer" }}
+    >
+      {badge}
+    </button>
+  );
+}

--- a/apps/web/src/lib/api/hooks.ts
+++ b/apps/web/src/lib/api/hooks.ts
@@ -10,6 +10,7 @@ import type {
   McpServer,
   Project,
   Provider,
+  ProviderHealth,
   ProviderModel,
   RoadmapEntry,
   Run,
@@ -28,6 +29,8 @@ export const useIssues = (projectId: string | null, state = "open") =>
 export const useRoadmap = (projectId: string | null) =>
   useSWR<RoadmapEntry[]>(projectId ? `/api/projects/${projectId}/roadmap` : null, fetcher);
 export const useProviders = () => useSWR<Provider[]>("/api/providers", fetcher);
+export const useProviderHealth = (providerId: string | null) =>
+  useSWR<ProviderHealth>(providerId ? `/api/providers/${providerId}/health` : null, fetcher);
 export const useProviderModels = (providerId: string | null) =>
   useSWR<ProviderModel[]>(providerId ? `/api/providers/${providerId}/models` : null, fetcher);
 export const useAgents = () => useSWR<Agent[]>("/api/agents", fetcher);

--- a/apps/web/src/lib/api/hooks.ts
+++ b/apps/web/src/lib/api/hooks.ts
@@ -30,7 +30,11 @@ export const useRoadmap = (projectId: string | null) =>
   useSWR<RoadmapEntry[]>(projectId ? `/api/projects/${projectId}/roadmap` : null, fetcher);
 export const useProviders = () => useSWR<Provider[]>("/api/providers", fetcher);
 export const useProviderHealth = (providerId: string | null) =>
-  useSWR<ProviderHealth>(providerId ? `/api/providers/${providerId}/health` : null, fetcher);
+  useSWR<ProviderHealth>(providerId ? `/api/providers/${providerId}/health` : null, fetcher, {
+    revalidateOnFocus: false,
+    revalidateOnReconnect: false,
+    revalidateIfStale: false,
+  });
 export const useProviderModels = (providerId: string | null) =>
   useSWR<ProviderModel[]>(providerId ? `/api/providers/${providerId}/models` : null, fetcher);
 export const useAgents = () => useSWR<Agent[]>("/api/agents", fetcher);

--- a/apps/web/src/lib/api/types.ts
+++ b/apps/web/src/lib/api/types.ts
@@ -78,9 +78,15 @@ export type Provider = {
   has_api_key: boolean;
   config: Record<string, unknown>;
   enabled: boolean;
+  last_health_status: "ok" | "unreachable" | "unauthorized" | "no-models" | null;
+  last_health_error: string | null;
+  last_health_checked_at: string | null;
 };
 
-export type ProviderInput = Omit<Provider, "id" | "workspace_id" | "has_api_key"> & {
+export type ProviderInput = Omit<
+  Provider,
+  "id" | "workspace_id" | "has_api_key" | "last_health_status" | "last_health_error" | "last_health_checked_at"
+> & {
   api_key?: string;
 };
 
@@ -94,6 +100,13 @@ export type ProviderModel = {
   input_cost_per_mtok: number | null;
   output_cost_per_mtok: number | null;
   last_seen_at: string | null;
+};
+
+export type ProviderHealth = {
+  provider_id: string;
+  status: "ok" | "unreachable" | "unauthorized" | "no-models";
+  error: string | null;
+  checked_at: string;
 };
 
 export type ModelPolicy = {

--- a/apps/web/src/lib/api/types.ts
+++ b/apps/web/src/lib/api/types.ts
@@ -78,7 +78,7 @@ export type Provider = {
   has_api_key: boolean;
   config: Record<string, unknown>;
   enabled: boolean;
-  last_health_status: "ok" | "unreachable" | "unauthorized" | "no-models" | null;
+  last_health_status: "ok" | "unreachable" | "unauthorized" | "no-models" | "unsupported" | null;
   last_health_error: string | null;
   last_health_checked_at: string | null;
 };
@@ -104,7 +104,7 @@ export type ProviderModel = {
 
 export type ProviderHealth = {
   provider_id: string;
-  status: "ok" | "unreachable" | "unauthorized" | "no-models";
+  status: "ok" | "unreachable" | "unauthorized" | "no-models" | "unsupported";
   error: string | null;
   checked_at: string;
 };

--- a/public/WHATS_NEW.md
+++ b/public/WHATS_NEW.md
@@ -2,3 +2,4 @@
 
 - Added system-aware light/dark mode support with a top-right toggle in the web application header.
 - Added a first-run onboarding wizard and workspace onboarding status APIs to guide setup through workspace naming, first project creation, and first provider connection.
+- Added provider health probes with persisted status/error reporting, provider badges, and a dedicated health summary page.


### PR DESCRIPTION
## Summary
- Add persisted provider health fields and migration, plus `GET /api/providers/{id}/health` to run and store provider probes.
- Auto-probe provider health on create/update and classify results as `ok`, `unreachable`, `unauthorized`, or `no-models` with raw error details.
- Render health status badges on the providers page, add manual health refresh, and add a new `/health` summary page for all providers.

## Test plan
- [x] `yarn build`
- [x] `yarn workspace @ouroboros/api test tests/test_providers_api.py`
- [ ] `yarn test` *(currently fails in existing `apps/web/src/components/onboarding/wizard.test.tsx` with timeout waiting for "Name your workspace")*

## Risk / Notes
- `apps/web/next-env.d.ts` updated from build output (`./.next/dev/types/routes.d.ts` -> `./.next/types/routes.d.ts`).
- Could not mark a ROADMAP ticket entry complete because no ROADMAP file exists in this repository tree.

Closes #8

Made with [Cursor](https://cursor.com)