### PR TITLE
Fix #9 - auto-detect repo build/test commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## 2026-04-19
+
+- Added project repo introspection (`/api/projects/{id}/introspect`) to detect build/test command candidates from common manifests.
+- Added one-click command suggestion chips in the Projects UI for build and test fields.

--- a/PLANNED_FEATURE_ROADMAP_2026.md
+++ b/PLANNED_FEATURE_ROADMAP_2026.md
@@ -17,6 +17,7 @@ Legend
 Completed
 - #67 - Added system-aware light/dark mode with a top-right header toggle in the web app.
 - #7 - Added a first-run onboarding wizard for workspace setup, initial project connection, and first provider setup.
+- #9 - Added repository command introspection to suggest build/test commands in the project editor.
 
 ---
 
@@ -34,7 +35,6 @@ Completed
 | #     | Issue                                                                                          | Tier | Notes                                                    |
 |-------|------------------------------------------------------------------------------------------------|------|----------------------------------------------------------|
 | #8 | Healthcheck panel: ping each configured provider, surface "needs key" / "ollama unreachable"   | MVP  | New `GET /api/providers/{id}/health` and a `/health` page       |
-| #9 | Auto-detect repo `build`/`test` commands (package.json scripts, pyproject sections, Makefile)  | MVP  | Pre-fills Project commands so first run "just works"             |
 | #10 | Improved router default policy (per-language) baked into seed agents, not just `coder`         | MVP  | Currently only the `coder` agent has language hints              |
 | #11 | Real-time stderr/stdout streaming for shell steps (not just final blob)                        | MVP  | New `step.log` events on the WebSocket bus                       |
 | #12 | Persisted `.env` for `OUROBOROS_DB_URL` etc. via `ouroboros init` CLI                          | MVP  | Today envs are read but never written for the user               |

--- a/apps/api/ouroboros_api/api/projects.py
+++ b/apps/api/ouroboros_api/api/projects.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import anyio
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -90,5 +91,7 @@ async def introspect_project(
     session: AsyncSession = Depends(db_session),
 ) -> ProjectIntrospectionOut:
     project = await _project_or_404(project_id, ws, session)
-    suggestions = introspect_project_commands(project)
+    suggestions = await anyio.to_thread.run_sync(
+        lambda: introspect_project_commands(project)
+    )
     return ProjectIntrospectionOut(**suggestions.as_dict())

--- a/apps/api/ouroboros_api/api/projects.py
+++ b/apps/api/ouroboros_api/api/projects.py
@@ -7,10 +7,18 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from ..db.models import Project, Workspace
+from ..services.repo_introspect import introspect_project_commands, repo_introspector
 from .deps import db_session, workspace
-from .schemas import ProjectIn, ProjectOut
+from .schemas import ProjectIn, ProjectIntrospectionOut, ProjectOut
 
 router = APIRouter(prefix="/api/projects", tags=["projects"])
+
+
+async def _project_or_404(project_id: str, ws: Workspace, session: AsyncSession) -> Project:
+    project = await session.get(Project, project_id)
+    if not project or project.workspace_id != ws.id:
+        raise HTTPException(404, "Project not found")
+    return project
 
 
 @router.get("", response_model=list[ProjectOut])
@@ -33,6 +41,7 @@ async def create_project(
     session.add(project)
     await session.commit()
     await session.refresh(project)
+    repo_introspector.invalidate(project.id)
     return ProjectOut.model_validate(project)
 
 
@@ -42,9 +51,7 @@ async def get_project(
     ws: Workspace = Depends(workspace),
     session: AsyncSession = Depends(db_session),
 ) -> ProjectOut:
-    project = await session.get(Project, project_id)
-    if not project or project.workspace_id != ws.id:
-        raise HTTPException(404, "Project not found")
+    project = await _project_or_404(project_id, ws, session)
     return ProjectOut.model_validate(project)
 
 
@@ -55,9 +62,8 @@ async def update_project(
     ws: Workspace = Depends(workspace),
     session: AsyncSession = Depends(db_session),
 ) -> ProjectOut:
-    project = await session.get(Project, project_id)
-    if not project or project.workspace_id != ws.id:
-        raise HTTPException(404, "Project not found")
+    project = await _project_or_404(project_id, ws, session)
+    repo_introspector.invalidate(project.id)
     for key, value in payload.model_dump().items():
         setattr(project, key, value)
     await session.commit()
@@ -71,8 +77,18 @@ async def delete_project(
     ws: Workspace = Depends(workspace),
     session: AsyncSession = Depends(db_session),
 ) -> None:
-    project = await session.get(Project, project_id)
-    if not project or project.workspace_id != ws.id:
-        raise HTTPException(404, "Project not found")
+    project = await _project_or_404(project_id, ws, session)
+    repo_introspector.invalidate(project.id)
     await session.delete(project)
     await session.commit()
+
+
+@router.get("/{project_id}/introspect", response_model=ProjectIntrospectionOut)
+async def introspect_project(
+    project_id: str,
+    ws: Workspace = Depends(workspace),
+    session: AsyncSession = Depends(db_session),
+) -> ProjectIntrospectionOut:
+    project = await _project_or_404(project_id, ws, session)
+    suggestions = introspect_project_commands(project)
+    return ProjectIntrospectionOut(**suggestions.as_dict())

--- a/apps/api/ouroboros_api/api/schemas.py
+++ b/apps/api/ouroboros_api/api/schemas.py
@@ -53,6 +53,11 @@ class ProjectOut(ProjectIn):
     updated_at: datetime
 
 
+class ProjectIntrospectionOut(_Base):
+    build: list[str] = Field(default_factory=list)
+    test: list[str] = Field(default_factory=list)
+
+
 class IssueOut(_Base):
     id: str
     project_id: str

--- a/apps/api/ouroboros_api/services/repo_introspect.py
+++ b/apps/api/ouroboros_api/services/repo_introspect.py
@@ -15,7 +15,6 @@ from ..config import settings
 from ..db.models import Project
 
 _TARGET_FILES = ("package.json", "pyproject.toml", "Makefile", "Cargo.toml", "go.mod")
-_TARGET_FILE_SET = set(_TARGET_FILES)
 
 
 @dataclass(slots=True)
@@ -41,7 +40,7 @@ def _resolve_repo_root(project: Project) -> Path | None:
         if candidate.exists():
             return candidate
     cached = settings.data_dir / "introspect-cache" / project.id
-    if cached.exists():
+    if cached.exists() and (cached / ".git").exists():
         return cached
     return None
 
@@ -52,13 +51,22 @@ def _shallow_clone(project: Project) -> Path | None:
     if target.exists():
         shutil.rmtree(target)
 
-    cmd = ["git", "clone", "--depth", "1"]
+    # protocol.file.allow=never requires Git >= 2.38.0 (Oct 2022)
+    cmd = ["git", "-c", "protocol.file.allow=never", "clone", "--depth", "1"]
     if project.default_branch:
         cmd.extend(["--branch", project.default_branch])
-    cmd.extend([project.repo_url, str(target)])
+    cmd.extend(["--", project.repo_url, str(target)])
     try:
-        subprocess.run(cmd, check=True, capture_output=True)
+        subprocess.run(
+            cmd,
+            check=True,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            timeout=60,
+        )
     except Exception:
+        if target.exists():
+            shutil.rmtree(target)
         return None
     return target
 
@@ -70,7 +78,10 @@ def _safe_read_text(path: Path) -> str:
 def _load_toml(path: Path) -> dict[str, Any]:
     import tomllib
 
-    return tomllib.loads(_safe_read_text(path))
+    try:
+        return tomllib.loads(_safe_read_text(path))
+    except tomllib.TOMLDecodeError:
+        return {}
 
 
 def _normalize_test_script(script: str) -> str:
@@ -83,7 +94,10 @@ def _normalize_test_script(script: str) -> str:
 
 
 def _suggest_from_package_json(path: Path, suggestions: RepoCommandSuggestions) -> None:
-    data = json.loads(_safe_read_text(path))
+    try:
+        data = json.loads(_safe_read_text(path))
+    except json.JSONDecodeError:
+        return
     scripts = data.get("scripts")
     if not isinstance(scripts, dict):
         return

--- a/apps/api/ouroboros_api/services/repo_introspect.py
+++ b/apps/api/ouroboros_api/services/repo_introspect.py
@@ -1,0 +1,186 @@
+"""Detect candidate build/test commands from common repo manifests."""
+
+from __future__ import annotations
+
+import json
+import re
+import shutil
+import subprocess
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from ..config import settings
+from ..db.models import Project
+
+_TARGET_FILES = ("package.json", "pyproject.toml", "Makefile", "Cargo.toml", "go.mod")
+_TARGET_FILE_SET = set(_TARGET_FILES)
+
+
+@dataclass(slots=True)
+class RepoCommandSuggestions:
+    build: list[str] = field(default_factory=list)
+    test: list[str] = field(default_factory=list)
+
+    def as_dict(self) -> dict[str, list[str]]:
+        return {"build": self.build, "test": self.test}
+
+
+def _append_unique(values: list[str], value: str | None) -> None:
+    if not value:
+        return
+    trimmed = value.strip()
+    if trimmed and trimmed not in values:
+        values.append(trimmed)
+
+
+def _resolve_repo_root(project: Project) -> Path | None:
+    if project.local_clone_hint:
+        candidate = Path(project.local_clone_hint).expanduser()
+        if candidate.exists():
+            return candidate
+    cached = settings.data_dir / "introspect-cache" / project.id
+    if cached.exists():
+        return cached
+    return None
+
+
+def _shallow_clone(project: Project) -> Path | None:
+    target = settings.data_dir / "introspect-cache" / project.id
+    target.parent.mkdir(parents=True, exist_ok=True)
+    if target.exists():
+        shutil.rmtree(target)
+
+    cmd = ["git", "clone", "--depth", "1"]
+    if project.default_branch:
+        cmd.extend(["--branch", project.default_branch])
+    cmd.extend([project.repo_url, str(target)])
+    try:
+        subprocess.run(cmd, check=True, capture_output=True)
+    except Exception:
+        return None
+    return target
+
+
+def _safe_read_text(path: Path) -> str:
+    return path.read_text(encoding="utf-8", errors="replace")
+
+
+def _load_toml(path: Path) -> dict[str, Any]:
+    import tomllib
+
+    return tomllib.loads(_safe_read_text(path))
+
+
+def _normalize_test_script(script: str) -> str:
+    parts = script.strip().split()
+    if not parts:
+        return script
+    if parts[0] == "vitest" and "run" not in parts:
+        return "vitest run"
+    return script.strip()
+
+
+def _suggest_from_package_json(path: Path, suggestions: RepoCommandSuggestions) -> None:
+    data = json.loads(_safe_read_text(path))
+    scripts = data.get("scripts")
+    if not isinstance(scripts, dict):
+        return
+
+    build_script = scripts.get("build")
+    if isinstance(build_script, str):
+        _append_unique(suggestions.build, build_script)
+        _append_unique(suggestions.build, "npm run build")
+
+    test_script = scripts.get("test")
+    if isinstance(test_script, str):
+        _append_unique(suggestions.test, _normalize_test_script(test_script))
+        _append_unique(suggestions.test, "npm test")
+
+    ci_test_script = scripts.get("test:ci")
+    if isinstance(ci_test_script, str):
+        _append_unique(suggestions.test, _normalize_test_script(ci_test_script))
+
+
+def _suggest_from_pyproject(path: Path, suggestions: RepoCommandSuggestions) -> None:
+    data = _load_toml(path)
+    tool = data.get("tool")
+    if isinstance(tool, dict) and isinstance(tool.get("pytest"), dict):
+        _append_unique(suggestions.test, "uv run pytest -q")
+
+    if isinstance(data.get("build-system"), dict):
+        _append_unique(suggestions.build, "python -m build")
+
+
+def _suggest_from_makefile(path: Path, suggestions: RepoCommandSuggestions) -> None:
+    text = _safe_read_text(path)
+    targets: set[str] = set()
+    for line in text.splitlines():
+        match = re.match(r"^([A-Za-z0-9_.-]+)\s*:(?![=])", line)
+        if match:
+            targets.add(match.group(1).lower())
+
+    if "build" in targets:
+        _append_unique(suggestions.build, "make build")
+    if "test" in targets:
+        _append_unique(suggestions.test, "make test")
+    if "check" in targets:
+        _append_unique(suggestions.test, "make check")
+
+
+def _suggest_from_repo(root: Path) -> RepoCommandSuggestions:
+    suggestions = RepoCommandSuggestions()
+
+    package_json = root / "package.json"
+    if package_json.exists():
+        _suggest_from_package_json(package_json, suggestions)
+
+    pyproject = root / "pyproject.toml"
+    if pyproject.exists():
+        _suggest_from_pyproject(pyproject, suggestions)
+
+    makefile = root / "Makefile"
+    if makefile.exists():
+        _suggest_from_makefile(makefile, suggestions)
+
+    if (root / "Cargo.toml").exists():
+        _append_unique(suggestions.build, "cargo build")
+        _append_unique(suggestions.test, "cargo test")
+
+    if (root / "go.mod").exists():
+        _append_unique(suggestions.build, "go build ./...")
+        _append_unique(suggestions.test, "go test ./...")
+
+    return suggestions
+
+
+@dataclass(slots=True)
+class RepoIntrospector:
+    ttl_seconds: int = 3600
+    _cache: dict[str, tuple[float, RepoCommandSuggestions]] = field(default_factory=dict)
+
+    def introspect(self, project: Project) -> RepoCommandSuggestions:
+        now = time.time()
+        cache_key = project.id
+        cached = self._cache.get(cache_key)
+        if cached and now - cached[0] < self.ttl_seconds:
+            return cached[1]
+
+        root = _resolve_repo_root(project) or _shallow_clone(project)
+        if root is None:
+            result = RepoCommandSuggestions()
+        else:
+            result = _suggest_from_repo(root)
+        self._cache[cache_key] = (now, result)
+        return result
+
+    def invalidate(self, project_id: str) -> None:
+        self._cache.pop(project_id, None)
+
+
+repo_introspector = RepoIntrospector()
+
+
+def introspect_project_commands(project: Project) -> RepoCommandSuggestions:
+    return repo_introspector.introspect(project)

--- a/apps/api/pyproject.toml
+++ b/apps/api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ouroboros-api"
-version = "0.1.0"
+version = "0.1.1"
 description = "Ouroboros orchestrator API: agent pipelines, dry-run, MCP, multi-provider LLM routing."
 requires-python = ">=3.12"
 readme = "README.md"

--- a/apps/api/tests/test_projects_introspect_api.py
+++ b/apps/api/tests/test_projects_introspect_api.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+import json
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from pathlib import Path
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from ouroboros_api.api import deps
+from ouroboros_api.db.models import Base, Project, Workspace
+from ouroboros_api.main import create_app
+
+
+@pytest_asyncio.fixture
+async def app_and_session(
+    tmp_path: Path,
+) -> AsyncIterator[tuple[object, async_sessionmaker[AsyncSession]]]:
+    db_path = tmp_path / "projects-introspect.sqlite"
+    engine = create_async_engine(
+        f"sqlite+aiosqlite:///{db_path}",
+        connect_args={"check_same_thread": False},
+    )
+    session_factory = async_sessionmaker(engine, expire_on_commit=False, class_=AsyncSession)
+
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+    async with session_factory() as session:
+        session.add(Workspace(slug="default", name="Default Workspace"))
+        await session.commit()
+
+    app = create_app()
+
+    @asynccontextmanager
+    async def noop_lifespan(_app: object) -> AsyncIterator[None]:
+        yield
+
+    app.router.lifespan_context = noop_lifespan  # type: ignore[method-assign]
+
+    async def override_db_session() -> AsyncIterator[AsyncSession]:
+        async with session_factory() as session:
+            yield session
+
+    app.dependency_overrides[deps.db_session] = override_db_session
+    try:
+        yield app, session_factory
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_project_introspect_suggests_from_package_and_pyproject(
+    app_and_session: tuple[object, async_sessionmaker[AsyncSession]],
+    tmp_path: Path,
+) -> None:
+    app, session_factory = app_and_session
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "package.json").write_text(
+        json.dumps({"scripts": {"build": "next build", "test": "vitest"}}),
+        encoding="utf-8",
+    )
+    (repo / "pyproject.toml").write_text(
+        "[tool.pytest.ini_options]\naddopts = \"-q\"\n",
+        encoding="utf-8",
+    )
+
+    async with session_factory() as session:
+        workspace = (
+            await session.execute(select(Workspace).where(Workspace.slug == "default"))
+        ).scalar_one()
+        project = Project(
+            workspace_id=workspace.id,
+            name="Demo",
+            repo_url="https://github.com/acme/demo",
+            scm_kind="github",
+            default_branch="main",
+            local_clone_hint=str(repo),
+        )
+        session.add(project)
+        await session.commit()
+        await session.refresh(project)
+        project_id = project.id
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        res = await client.get(f"/api/projects/{project_id}/introspect")
+
+    assert res.status_code == 200
+    payload = res.json()
+    assert "next build" in payload["build"]
+    assert "vitest run" in payload["test"]
+    assert "uv run pytest -q" in payload["test"]
+
+
+@pytest.mark.asyncio
+async def test_project_introspect_returns_empty_when_no_known_manifests(
+    app_and_session: tuple[object, async_sessionmaker[AsyncSession]],
+    tmp_path: Path,
+) -> None:
+    app, session_factory = app_and_session
+
+    repo = tmp_path / "repo-empty"
+    repo.mkdir()
+    (repo / "README.md").write_text("# Empty\n", encoding="utf-8")
+
+    async with session_factory() as session:
+        workspace = (
+            await session.execute(select(Workspace).where(Workspace.slug == "default"))
+        ).scalar_one()
+        project = Project(
+            workspace_id=workspace.id,
+            name="No Manifest",
+            repo_url="https://github.com/acme/no-manifest",
+            scm_kind="github",
+            default_branch="main",
+            local_clone_hint=str(repo),
+        )
+        session.add(project)
+        await session.commit()
+        await session.refresh(project)
+        project_id = project.id
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        res = await client.get(f"/api/projects/{project_id}/introspect")
+
+    assert res.status_code == 200
+    assert res.json() == {"build": [], "test": []}

--- a/apps/api/uv.lock
+++ b/apps/api/uv.lock
@@ -986,7 +986,7 @@ wheels = [
 
 [[package]]
 name = "ouroboros-api"
-version = "0.1.0"
+version = "0.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ouroboros-web",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "private": true,
   "scripts": {
     "dev": "next dev -p 3000",

--- a/apps/web/src/app/projects/page.tsx
+++ b/apps/web/src/app/projects/page.tsx
@@ -12,7 +12,7 @@ import {
 } from "@radix-ui/themes";
 import { PageShell, PageHeader } from "@/components/layout/page-shell";
 import { SidebarList } from "@/components/common/sidebar-list";
-import { useProjects } from "@/lib/api/hooks";
+import { useProjectIntrospection, useProjects } from "@/lib/api/hooks";
 import { api } from "@/lib/api/client";
 import type { Project, ProjectInput } from "@/lib/api/types";
 import { mutate } from "swr";
@@ -33,6 +33,7 @@ export default function ProjectsPage() {
   const { data: projects = [], isLoading } = useProjects();
   const [activeId, setActiveId] = useState<string | null>(null);
   const [draft, setDraft] = useState<ProjectInput | null>(null);
+  const { data: introspection } = useProjectIntrospection(activeId);
 
   const active = activeId ? projects.find((p) => p.id === activeId) ?? null : null;
   const editing = draft ?? (active as ProjectInput | null);
@@ -129,6 +130,13 @@ export default function ProjectsPage() {
                   value={editing.build_command || ""}
                   onChange={(e) => update({ build_command: e.target.value || null })}
                 />
+                {active ? (
+                  <SuggestionChips
+                    commands={introspection?.build ?? []}
+                    current={editing.build_command}
+                    onUse={(command) => update({ build_command: command })}
+                  />
+                ) : null}
               </Field>
               <Field label="Test command" style={{ flex: 1 }}>
                 <TextField.Root
@@ -136,6 +144,13 @@ export default function ProjectsPage() {
                   value={editing.test_command || ""}
                   onChange={(e) => update({ test_command: e.target.value || null })}
                 />
+                {active ? (
+                  <SuggestionChips
+                    commands={introspection?.test ?? []}
+                    current={editing.test_command}
+                    onUse={(command) => update({ test_command: command })}
+                  />
+                ) : null}
               </Field>
             </Flex>
             <Field label="Config (JSON, advanced)">
@@ -157,6 +172,31 @@ export default function ProjectsPage() {
         <div className="empty-state">Select or create a project</div>
       )}
     </PageShell>
+  );
+}
+
+function SuggestionChips({
+  commands,
+  current,
+  onUse,
+}: {
+  commands: string[];
+  current: string | null;
+  onUse: (command: string) => void;
+}) {
+  const options = commands.filter((command) => command !== current);
+  if (!options.length) return null;
+  return (
+    <Flex mt="2" gap="2" wrap="wrap" align="center">
+      <Text size="1" color="gray">
+        Suggestions
+      </Text>
+      {options.map((command) => (
+        <Button key={command} size="1" variant="soft" onClick={() => onUse(command)}>
+          Use this: {command}
+        </Button>
+      ))}
+    </Flex>
   );
 }
 

--- a/apps/web/src/lib/api/hooks.ts
+++ b/apps/web/src/lib/api/hooks.ts
@@ -9,6 +9,7 @@ import type {
   McpRegistryEntry,
   McpServer,
   Project,
+  ProjectIntrospection,
   Provider,
   ProviderHealth,
   ProviderModel,
@@ -24,6 +25,11 @@ export const useProjects = () => useSWR<Project[]>("/api/projects", fetcher);
 export const useWorkspaceOnboarding = () =>
   useSWR<WorkspaceOnboardingStatus>("/api/workspaces/me", fetcher);
 export const useProject = (id: string | null) => useSWR<Project>(id ? `/api/projects/${id}` : null, fetcher);
+export const useProjectIntrospection = (id: string | null) =>
+  useSWR<ProjectIntrospection>(id ? `/api/projects/${id}/introspect` : null, fetcher, {
+    revalidateOnFocus: false,
+    revalidateOnReconnect: false,
+  });
 export const useIssues = (projectId: string | null, state = "open") =>
   useSWR<Issue[]>(projectId ? `/api/projects/${projectId}/issues?state=${state}` : null, fetcher);
 export const useRoadmap = (projectId: string | null) =>

--- a/apps/web/src/lib/api/types.ts
+++ b/apps/web/src/lib/api/types.ts
@@ -36,6 +36,11 @@ export type Project = {
 
 export type ProjectInput = Omit<Project, "id" | "workspace_id" | "created_at" | "updated_at">;
 
+export type ProjectIntrospection = {
+  build: string[];
+  test: string[];
+};
+
 export type Issue = {
   id: string;
   project_id: string;

--- a/public/WHATS_NEW.md
+++ b/public/WHATS_NEW.md
@@ -3,3 +3,4 @@
 - Added system-aware light/dark mode support with a top-right toggle in the web application header.
 - Added a first-run onboarding wizard and workspace onboarding status APIs to guide setup through workspace naming, first project creation, and first provider connection.
 - Added provider health probes with persisted status/error reporting, provider badges, and a dedicated health summary page.
+- Added repo manifest introspection with build/test command suggestions and one-click "Use this" actions on the Projects page.


### PR DESCRIPTION
## Summary
- add `repo_introspect` service to scan repo manifests (`package.json`, `pyproject.toml`, `Makefile`, `Cargo.toml`, `go.mod`) and return build/test command candidates
- add cached endpoint `GET /api/projects/{id}/introspect` (1h in-memory cache, invalidated on project create/update/delete)
- add Projects page suggestion chips for build/test fields with one-click `Use this` actions (advisory only; never auto-overwrites)
- add API coverage for manifest suggestions and empty-manifest fallback, then update roadmap/changelog/what's-new entries and patch versions

## Test plan
- [x] `yarn build`
- [x] `cd apps/api && ./scripts/with-venv.sh uv run ruff check ouroboros_api/services/repo_introspect.py ouroboros_api/api/projects.py ouroboros_api/api/schemas.py tests/test_projects_introspect_api.py`
- [x] `cd apps/api && ./scripts/with-venv.sh uv run pytest -q tests/test_projects_introspect_api.py`
- [x] `cd apps/web && yarn test src/lib/api/client.test.ts`
- [ ] `yarn test` *(currently fails in existing `apps/web/src/components/onboarding/wizard.test.tsx` with timeout waiting for "Name your workspace")*

## Risk / Notes
- endpoint cache is process-local in-memory; cache coherence across multiple API instances is not included in this change
- introspection falls back to a shallow clone when no local clone hint is available, but returns empty suggestions if clone fails

Closes #9

Made with [Cursor](https://cursor.com)