### PR TITLE
Fix #10 - default per-language router policy on seed agents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,5 +2,7 @@
 
 ## 2026-04-19
 
+- Added per-language router policy defaults to `issue.summarizer`, `planner`, and `internal.audit` seed agents, matching existing `coder` behavior.
+- Added migration `0004_seed_agent_router_language_hints` to backfill missing `language_map` hints on seeded router agents.
 - Added project repo introspection (`/api/projects/{id}/introspect`) to detect build/test command candidates from common manifests.
 - Added one-click command suggestion chips in the Projects UI for build and test fields.

--- a/PLANNED_FEATURE_ROADMAP_2026.md
+++ b/PLANNED_FEATURE_ROADMAP_2026.md
@@ -18,6 +18,7 @@ Completed
 - #67 - Added system-aware light/dark mode with a top-right header toggle in the web app.
 - #7 - Added a first-run onboarding wizard for workspace setup, initial project connection, and first provider setup.
 - #9 - Added repository command introspection to suggest build/test commands in the project editor.
+- #10 - Added per-language router policy defaults to all seed router agents.
 
 ---
 
@@ -35,7 +36,6 @@ Completed
 | #     | Issue                                                                                          | Tier | Notes                                                    |
 |-------|------------------------------------------------------------------------------------------------|------|----------------------------------------------------------|
 | #8 | Healthcheck panel: ping each configured provider, surface "needs key" / "ollama unreachable"   | MVP  | New `GET /api/providers/{id}/health` and a `/health` page       |
-| #10 | Improved router default policy (per-language) baked into seed agents, not just `coder`         | MVP  | Currently only the `coder` agent has language hints              |
 | #11 | Real-time stderr/stdout streaming for shell steps (not just final blob)                        | MVP  | New `step.log` events on the WebSocket bus                       |
 | #12 | Persisted `.env` for `OUROBOROS_DB_URL` etc. via `ouroboros init` CLI                          | MVP  | Today envs are read but never written for the user               |
 | #13 | "Resume" button when a run was interrupted by a crash mid-step                                 | MVP  | Engine has `attempts` but no resume from prior step              |

--- a/apps/api/ouroboros_api/db/migrations/versions/0004_seed_agent_router_language_hints.py
+++ b/apps/api/ouroboros_api/db/migrations/versions/0004_seed_agent_router_language_hints.py
@@ -1,0 +1,89 @@
+"""backfill router language hints for default agents
+
+Revision ID: 0004_seed_agent_router_language_hints
+Revises: 0003_provider_health_state
+Create Date: 2026-04-19
+
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0004_seed_agent_router_language_hints"
+down_revision = "0003_provider_health_state"
+branch_labels = None
+depends_on = None
+
+
+PLANNING_LANGUAGE_MAP = {
+    "python": {"prefer_kind": "anthropic", "model_hint": "sonnet"},
+    "typescript": {"prefer_kind": "anthropic", "model_hint": "sonnet"},
+}
+
+CODER_LANGUAGE_MAP = {
+    "python": {"prefer_kind": "ollama", "model_hint": "qwen2.5-coder"},
+    "typescript": {"prefer_kind": "anthropic", "model_hint": "claude-sonnet"},
+    "javascript": {"prefer_kind": "anthropic", "model_hint": "claude-sonnet"},
+    "sql": {"prefer_kind": "ollama", "model_hint": "sqlcoder"},
+    "rust": {"prefer_kind": "ollama", "model_hint": "qwen2.5-coder"},
+}
+
+LANGUAGE_MAP_BY_ROLE = {
+    "issue.summarizer": PLANNING_LANGUAGE_MAP,
+    "planner": PLANNING_LANGUAGE_MAP,
+    "internal.audit": PLANNING_LANGUAGE_MAP,
+    "coder": CODER_LANGUAGE_MAP,
+}
+
+
+def _needs_router_hints_update(policy: dict[str, Any]) -> bool:
+    if (policy or {}).get("kind") != "router":
+        return False
+    hints = (policy.get("router_hints") or {}) if isinstance(policy, dict) else {}
+    # Preserve existing language map customizations.
+    if not isinstance(hints, dict):
+        return True
+    return not hints.get("language_map")
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    agents = sa.table(
+        "agents",
+        sa.column("id", sa.String()),
+        sa.column("role", sa.String()),
+        sa.column("model_policy", sa.JSON()),
+    )
+
+    rows = bind.execute(
+        sa.select(agents.c.id, agents.c.role, agents.c.model_policy).where(
+            agents.c.role.in_(tuple(LANGUAGE_MAP_BY_ROLE))
+        )
+    ).fetchall()
+
+    for row in rows:
+        role = row.role
+        policy = row.model_policy or {}
+        if role not in LANGUAGE_MAP_BY_ROLE or not _needs_router_hints_update(policy):
+            continue
+
+        hints = policy.get("router_hints") if isinstance(policy.get("router_hints"), dict) else {}
+        hints = dict(hints)
+        hints["language_map"] = LANGUAGE_MAP_BY_ROLE[role]
+
+        patched_policy = dict(policy)
+        patched_policy["kind"] = "router"
+        patched_policy["router_hints"] = hints
+
+        bind.execute(
+            sa.update(agents).where(agents.c.id == row.id).values(model_policy=patched_policy)
+        )
+
+
+def downgrade() -> None:
+    # Data backfill only; preserve user/customized policies.
+    return None

--- a/apps/api/ouroboros_api/db/migrations/versions/0004_seed_agent_router_language_hints.py
+++ b/apps/api/ouroboros_api/db/migrations/versions/0004_seed_agent_router_language_hints.py
@@ -43,11 +43,14 @@ LANGUAGE_MAP_BY_ROLE = {
 def _needs_router_hints_update(policy: dict[str, Any]) -> bool:
     if (policy or {}).get("kind") != "router":
         return False
-    hints = (policy.get("router_hints") or {}) if isinstance(policy, dict) else {}
-    # Preserve existing language map customizations.
-    if not isinstance(hints, dict):
+    raw_hints = policy.get("router_hints") if isinstance(policy, dict) else None
+    # Preserve existing router_hints customizations, including malformed values.
+    # Only backfill when router_hints is missing or a dict without language_map.
+    if raw_hints is None:
         return True
-    return not hints.get("language_map")
+    if not isinstance(raw_hints, dict):
+        return False
+    return "language_map" not in raw_hints
 
 
 def upgrade() -> None:

--- a/apps/api/ouroboros_api/seeds/agents.py
+++ b/apps/api/ouroboros_api/seeds/agents.py
@@ -17,7 +17,10 @@ DEFAULT_AGENTS: list[dict[str, Any]] = [
     {
         "name": "Issue Summarizer",
         "role": "issue.summarizer",
-        "description": "Summarizes the issue, surfaces ambiguity, proposes clarifying questions.",
+        "description": (
+            "Summarizes the issue, surfaces ambiguity, and asks clarifying questions. "
+            "Python/TypeScript issues default to Anthropic Sonnet."
+        ),
         "system_prompt": (
             "You are reviewing a GitHub/GitLab issue. Produce a concise summary of intent, "
             "list any ambiguities, and propose clarifying questions if requirements are "
@@ -25,7 +28,16 @@ DEFAULT_AGENTS: list[dict[str, Any]] = [
             '{"summary":..., "questions":[...], "risk":"low|medium|high"}.'
         ),
         "execution_adapter": "anthropic_api",
-        "model_policy": {"kind": "router", "router_hints": {"prefer": "reasoning"}},
+        "model_policy": {
+            "kind": "router",
+            "router_hints": {
+                "prefer": "reasoning",
+                "language_map": {
+                    "python": {"prefer_kind": "anthropic", "model_hint": "sonnet"},
+                    "typescript": {"prefer_kind": "anthropic", "model_hint": "sonnet"},
+                },
+            },
+        },
         "config": {},
     },
     {
@@ -40,20 +52,35 @@ DEFAULT_AGENTS: list[dict[str, Any]] = [
     {
         "name": "Planner",
         "role": "planner",
-        "description": "Produces a structured plan: file list, risk, test plan.",
+        "description": (
+            "Produces a structured plan: file list, risk, and test plan. "
+            "Python/TypeScript issues default to Anthropic Sonnet."
+        ),
         "system_prompt": (
             "You are the planning agent. Read the summarized issue and the relevant repo "
             "context, then output a structured plan: target files, code changes, risks, "
             "and a test plan. Output strict JSON."
         ),
         "execution_adapter": "anthropic_api",
-        "model_policy": {"kind": "router", "router_hints": {"prefer": "reasoning"}},
+        "model_policy": {
+            "kind": "router",
+            "router_hints": {
+                "prefer": "reasoning",
+                "language_map": {
+                    "python": {"prefer_kind": "anthropic", "model_hint": "sonnet"},
+                    "typescript": {"prefer_kind": "anthropic", "model_hint": "sonnet"},
+                },
+            },
+        },
         "config": {},
     },
     {
         "name": "Coder",
         "role": "coder",
-        "description": "Applies the plan to the codebase. Routes per dominant language.",
+        "description": (
+            "Applies the plan to the codebase. Python defaults to Ollama Qwen Coder, "
+            "TypeScript to Anthropic Sonnet, and SQL to Ollama SQLCoder."
+        ),
         "system_prompt": (
             "You are the implementation agent. Apply the plan precisely. Use the available "
             "tools (read_file, write_file, run_shell). Keep changes minimal and tested."
@@ -76,14 +103,26 @@ DEFAULT_AGENTS: list[dict[str, Any]] = [
     {
         "name": "Internal Audit",
         "role": "internal.audit",
-        "description": "Reviews the diff for misuses, missing tests, hard-coded values.",
+        "description": (
+            "Reviews the diff for misuses, missing tests, and hard-coded values. "
+            "Python/TypeScript issues default to Anthropic Sonnet."
+        ),
         "system_prompt": (
             "You are the audit agent. Review the diff for safety, test coverage, "
             "hard-coded values (colors, secrets), DRY violations, and unclear naming. "
             "Output a list of findings with severity."
         ),
         "execution_adapter": "anthropic_api",
-        "model_policy": {"kind": "router", "router_hints": {"prefer": "reasoning"}},
+        "model_policy": {
+            "kind": "router",
+            "router_hints": {
+                "prefer": "reasoning",
+                "language_map": {
+                    "python": {"prefer_kind": "anthropic", "model_hint": "sonnet"},
+                    "typescript": {"prefer_kind": "anthropic", "model_hint": "sonnet"},
+                },
+            },
+        },
         "config": {},
     },
     {

--- a/apps/api/pyproject.toml
+++ b/apps/api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ouroboros-api"
-version = "0.1.1"
+version = "0.1.2"
 description = "Ouroboros orchestrator API: agent pipelines, dry-run, MCP, multi-provider LLM routing."
 requires-python = ">=3.12"
 readme = "README.md"

--- a/apps/api/tests/test_router.py
+++ b/apps/api/tests/test_router.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from types import SimpleNamespace
 
 from ouroboros_api.orchestrator.router import detect_language, pick_model
+from ouroboros_api.seeds.agents import DEFAULT_AGENTS
 
 
 def test_detect_language_from_file_extension_in_body() -> None:
@@ -33,6 +34,11 @@ def _model(pid: str, mid: str) -> SimpleNamespace:
     return SimpleNamespace(provider_id=pid, model_id=mid, input_cost_per_mtok=0.0, output_cost_per_mtok=0.0)
 
 
+def _seed_policy(role: str) -> dict:
+    spec = next(agent for agent in DEFAULT_AGENTS if agent["role"] == role)
+    return spec["model_policy"]
+
+
 def test_pick_model_respects_fixed_policy() -> None:
     agent = SimpleNamespace(
         role="coder",
@@ -56,6 +62,26 @@ def test_pick_model_router_uses_language_hint() -> None:
     models = {"p1": [_model("p1", "llama3")], "p2": [_model("p2", "claude-3-5-sonnet")]}
     out = pick_model(agent, providers, models, issue={"title": "x", "body": "src/x.py"})
     assert out and out[0].kind == "anthropic" and "sonnet" in out[1].model_id
+
+
+def test_pick_model_uses_planner_seed_policy_for_python_issue() -> None:
+    agent = SimpleNamespace(role="planner", model_policy=_seed_policy("planner"))
+    providers = [_provider("p1", "ollama"), _provider("p2", "anthropic")]
+    models = {"p1": [_model("p1", "llama3")], "p2": [_model("p2", "claude-3-5-sonnet")]}
+
+    out = pick_model(agent, providers, models, issue={"title": "x", "body": "src/foo.py"})
+
+    assert out and out[0].kind == "anthropic" and "sonnet" in out[1].model_id
+
+
+def test_pick_model_uses_coder_seed_policy_for_python_issue() -> None:
+    agent = SimpleNamespace(role="coder", model_policy=_seed_policy("coder"))
+    providers = [_provider("p1", "anthropic"), _provider("p2", "ollama")]
+    models = {"p1": [_model("p1", "claude-3-5-sonnet")], "p2": [_model("p2", "qwen2.5-coder")]}
+
+    out = pick_model(agent, providers, models, issue={"title": "x", "body": "src/foo.py"})
+
+    assert out and out[0].kind == "ollama" and "qwen" in out[1].model_id
 
 
 def test_pick_model_falls_back_to_first_enabled_provider() -> None:

--- a/apps/api/tests/test_router.py
+++ b/apps/api/tests/test_router.py
@@ -35,7 +35,9 @@ def _model(pid: str, mid: str) -> SimpleNamespace:
 
 
 def _seed_policy(role: str) -> dict:
-    spec = next(agent for agent in DEFAULT_AGENTS if agent["role"] == role)
+    spec = next((agent for agent in DEFAULT_AGENTS if agent["role"] == role), None)
+    if spec is None:
+        raise AssertionError(f"Missing default agent seed for role: {role}")
     return spec["model_policy"]
 
 

--- a/apps/api/tests/test_seed_agents_router_policy.py
+++ b/apps/api/tests/test_seed_agents_router_policy.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from ouroboros_api.db.models import Agent, Base
+from ouroboros_api.seeds.bootstrap import bootstrap_if_empty
+
+
+@pytest.mark.asyncio
+async def test_bootstrap_seeds_language_maps_for_router_agents(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db_path = tmp_path / "seed-router-policy.sqlite"
+    engine = create_async_engine(
+        f"sqlite+aiosqlite:///{db_path}",
+        connect_args={"check_same_thread": False},
+    )
+    session_factory = async_sessionmaker(engine, expire_on_commit=False, class_=AsyncSession)
+
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+    from ouroboros_api.db import session as session_module
+
+    monkeypatch.setattr(session_module, "SessionLocal", session_factory)
+
+    await bootstrap_if_empty()
+
+    async with session_factory() as session:
+        rows = (
+            await session.execute(
+                select(Agent.role, Agent.model_policy).where(
+                    Agent.role.in_(["issue.summarizer", "planner", "internal.audit", "coder"])
+                )
+            )
+        ).all()
+
+    by_role = {role: policy for role, policy in rows}
+    assert set(by_role) == {"issue.summarizer", "planner", "internal.audit", "coder"}
+
+    for role in ("issue.summarizer", "planner", "internal.audit"):
+        language_map = (by_role[role].get("router_hints") or {}).get("language_map") or {}
+        assert language_map["python"]["prefer_kind"] == "anthropic"
+        assert "sonnet" in language_map["python"]["model_hint"]
+        assert language_map["typescript"]["prefer_kind"] == "anthropic"
+        assert "sonnet" in language_map["typescript"]["model_hint"]
+
+    coder_map = (by_role["coder"].get("router_hints") or {}).get("language_map") or {}
+    assert coder_map["python"]["prefer_kind"] == "ollama"
+    assert "qwen" in coder_map["python"]["model_hint"]
+    assert coder_map["typescript"]["prefer_kind"] == "anthropic"
+    assert "sonnet" in coder_map["typescript"]["model_hint"]
+    assert coder_map["sql"]["prefer_kind"] == "ollama"
+    assert "sqlcoder" in coder_map["sql"]["model_hint"]
+
+    await engine.dispose()

--- a/apps/api/tests/test_seed_agents_router_policy.py
+++ b/apps/api/tests/test_seed_agents_router_policy.py
@@ -20,40 +20,41 @@ async def test_bootstrap_seeds_language_maps_for_router_agents(
     )
     session_factory = async_sessionmaker(engine, expire_on_commit=False, class_=AsyncSession)
 
-    async with engine.begin() as conn:
-        await conn.run_sync(Base.metadata.create_all)
+    try:
+        async with engine.begin() as conn:
+            await conn.run_sync(Base.metadata.create_all)
 
-    from ouroboros_api.db import session as session_module
+        from ouroboros_api.db import session as session_module
 
-    monkeypatch.setattr(session_module, "SessionLocal", session_factory)
+        monkeypatch.setattr(session_module, "SessionLocal", session_factory)
 
-    await bootstrap_if_empty()
+        await bootstrap_if_empty()
 
-    async with session_factory() as session:
-        rows = (
-            await session.execute(
-                select(Agent.role, Agent.model_policy).where(
-                    Agent.role.in_(["issue.summarizer", "planner", "internal.audit", "coder"])
+        async with session_factory() as session:
+            rows = (
+                await session.execute(
+                    select(Agent.role, Agent.model_policy).where(
+                        Agent.role.in_(["issue.summarizer", "planner", "internal.audit", "coder"])
+                    )
                 )
-            )
-        ).all()
+            ).all()
 
-    by_role = {role: policy for role, policy in rows}
-    assert set(by_role) == {"issue.summarizer", "planner", "internal.audit", "coder"}
+        by_role = {role: policy for role, policy in rows}
+        assert set(by_role) == {"issue.summarizer", "planner", "internal.audit", "coder"}
 
-    for role in ("issue.summarizer", "planner", "internal.audit"):
-        language_map = (by_role[role].get("router_hints") or {}).get("language_map") or {}
-        assert language_map["python"]["prefer_kind"] == "anthropic"
-        assert "sonnet" in language_map["python"]["model_hint"]
-        assert language_map["typescript"]["prefer_kind"] == "anthropic"
-        assert "sonnet" in language_map["typescript"]["model_hint"]
+        for role in ("issue.summarizer", "planner", "internal.audit"):
+            language_map = (by_role[role].get("router_hints") or {}).get("language_map") or {}
+            assert language_map["python"]["prefer_kind"] == "anthropic"
+            assert "sonnet" in language_map["python"]["model_hint"]
+            assert language_map["typescript"]["prefer_kind"] == "anthropic"
+            assert "sonnet" in language_map["typescript"]["model_hint"]
 
-    coder_map = (by_role["coder"].get("router_hints") or {}).get("language_map") or {}
-    assert coder_map["python"]["prefer_kind"] == "ollama"
-    assert "qwen" in coder_map["python"]["model_hint"]
-    assert coder_map["typescript"]["prefer_kind"] == "anthropic"
-    assert "sonnet" in coder_map["typescript"]["model_hint"]
-    assert coder_map["sql"]["prefer_kind"] == "ollama"
-    assert "sqlcoder" in coder_map["sql"]["model_hint"]
-
-    await engine.dispose()
+        coder_map = (by_role["coder"].get("router_hints") or {}).get("language_map") or {}
+        assert coder_map["python"]["prefer_kind"] == "ollama"
+        assert "qwen" in coder_map["python"]["model_hint"]
+        assert coder_map["typescript"]["prefer_kind"] == "anthropic"
+        assert "sonnet" in coder_map["typescript"]["model_hint"]
+        assert coder_map["sql"]["prefer_kind"] == "ollama"
+        assert "sqlcoder" in coder_map["sql"]["model_hint"]
+    finally:
+        await engine.dispose()

--- a/apps/api/uv.lock
+++ b/apps/api/uv.lock
@@ -986,7 +986,7 @@ wheels = [
 
 [[package]]
 name = "ouroboros-api"
-version = "0.1.1"
+version = "0.1.2"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },

--- a/public/WHATS_NEW.md
+++ b/public/WHATS_NEW.md
@@ -4,3 +4,4 @@
 - Added a first-run onboarding wizard and workspace onboarding status APIs to guide setup through workspace naming, first project creation, and first provider connection.
 - Added provider health probes with persisted status/error reporting, provider badges, and a dedicated health summary page.
 - Added repo manifest introspection with build/test command suggestions and one-click "Use this" actions on the Projects page.
+- Added per-language router defaults for planner/summarizer/audit/coder seed agents, with backfill migration coverage for existing installs.


### PR DESCRIPTION
## Summary
- Add per-language `router_hints.language_map` defaults to `issue.summarizer`, `planner`, and `internal.audit` in `DEFAULT_AGENTS`, and document the routing choices in agent descriptions.
- Keep `coder` language routing defaults and add a one-shot Alembic migration (`0004_seed_agent_router_language_hints`) that backfills missing language maps for seeded router agents in existing databases.
- Add tests covering bootstrap-seeded policies and router selection behavior for Python issues (planner routes to Anthropic Sonnet, coder routes to Ollama Qwen), while preserving per-run override precedence.

## Test plan
- [x] `yarn --cwd apps/api build`
- [x] `yarn --cwd apps/api test`
- [x] `yarn --cwd apps/api test -k "router or seed"`
- [x] `yarn build`
- [ ] `yarn test` *(fails due existing unrelated web test: `apps/web/src/components/onboarding/wizard.test.tsx` timing out on "Name your workspace")*

## Risk / notes
- Migration intentionally updates only router agents missing `router_hints.language_map` so existing user-customized mappings are preserved.
- Existing repos with non-empty `router_hints` but no language map are upgraded for the four seeded roles.

Fixes #10

Made with [Cursor](https://cursor.com)