### PR TITLE
Fix #11 - real-time stdout/stderr streaming for shell steps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 2026-04-19
 
+- Added line-by-line shell output streaming via `step.log` run events and surfaced live per-step log panes on the run detail timeline.
+- Added shell runner cancellation handling to terminate in-flight subprocesses when runs are cancelled.
 - Added per-language router policy defaults to `issue.summarizer`, `planner`, and `internal.audit` seed agents, matching existing `coder` behavior.
 - Added migration `0004_seed_agent_router_language_hints` to backfill missing `language_map` hints on seeded router agents.
 - Added project repo introspection (`/api/projects/{id}/introspect`) to detect build/test command candidates from common manifests.

--- a/PLANNED_FEATURE_ROADMAP_2026.md
+++ b/PLANNED_FEATURE_ROADMAP_2026.md
@@ -19,6 +19,7 @@ Completed
 - #7 - Added a first-run onboarding wizard for workspace setup, initial project connection, and first provider setup.
 - #9 - Added repository command introspection to suggest build/test commands in the project editor.
 - #10 - Added per-language router policy defaults to all seed router agents.
+- #11 - Added real-time stdout/stderr streaming for shell steps with step-level live logs.
 
 ---
 
@@ -36,7 +37,6 @@ Completed
 | #     | Issue                                                                                          | Tier | Notes                                                    |
 |-------|------------------------------------------------------------------------------------------------|------|----------------------------------------------------------|
 | #8 | Healthcheck panel: ping each configured provider, surface "needs key" / "ollama unreachable"   | MVP  | New `GET /api/providers/{id}/health` and a `/health` page       |
-| #11 | Real-time stderr/stdout streaming for shell steps (not just final blob)                        | MVP  | New `step.log` events on the WebSocket bus                       |
 | #12 | Persisted `.env` for `OUROBOROS_DB_URL` etc. via `ouroboros init` CLI                          | MVP  | Today envs are read but never written for the user               |
 | #13 | "Resume" button when a run was interrupted by a crash mid-step                                 | MVP  | Engine has `attempts` but no resume from prior step              |
 | #14 | Robust dry-run diff viewer: real side-by-side using Monaco's `DiffEditor`                      | MVP  | Current `DiffViewer` is a thin wrapper; needs left/right inputs  |

--- a/apps/api/ouroboros_api/orchestrator/engine.py
+++ b/apps/api/ouroboros_api/orchestrator/engine.py
@@ -25,7 +25,7 @@ from ..db.models import (
     RunStep,
 )
 from ..db.session import SessionLocal
-from ..sandbox import VirtualFs, prepare_sandbox
+from ..sandbox import VirtualFs, prepare_sandbox, shell_line_subscriber
 from ..secrets import secrets
 from .context import RunContext
 from .cost import estimate_cost_usd
@@ -256,8 +256,18 @@ class RunEngine:
                 session, run, step, StepResult(summary="bad adapter", failed=True, error=str(exc))
             )
 
+        async def _publish_step_log(stream: str, line: str) -> None:
+            await bus.publish(
+                RunEvent(
+                    run_id=run.id,
+                    type="step.log",
+                    payload={"step_id": step.id, "stream": stream, "line": line},
+                )
+            )
+
         try:
-            result = await adapter.run(ctx, agent, resolved)
+            with shell_line_subscriber(_publish_step_log):
+                result = await adapter.run(ctx, agent, resolved)
         except Exception as exc:
             log.exception("step failed")
             result = StepResult(summary="step crashed", failed=True, error=str(exc))

--- a/apps/api/ouroboros_api/orchestrator/engine.py
+++ b/apps/api/ouroboros_api/orchestrator/engine.py
@@ -262,7 +262,8 @@ class RunEngine:
                     run_id=run.id,
                     type="step.log",
                     payload={"step_id": step.id, "stream": stream, "line": line},
-                )
+                ),
+                persist=False,
             )
 
         try:

--- a/apps/api/ouroboros_api/orchestrator/events.py
+++ b/apps/api/ouroboros_api/orchestrator/events.py
@@ -26,9 +26,10 @@ class RunEventBus:
         self._history: dict[str, list[RunEvent]] = defaultdict(list)
         self._lock = asyncio.Lock()
 
-    async def publish(self, event: RunEvent) -> None:
+    async def publish(self, event: RunEvent, *, persist: bool = True) -> None:
         async with self._lock:
-            self._history[event.run_id].append(event)
+            if persist:
+                self._history[event.run_id].append(event)
             for q in list(self._queues[event.run_id]):
                 try:
                     q.put_nowait(event)

--- a/apps/api/ouroboros_api/sandbox/__init__.py
+++ b/apps/api/ouroboros_api/sandbox/__init__.py
@@ -1,6 +1,6 @@
 """Sandbox: per-run isolated git clone + constrained shell + virtual FS for dry-run."""
 
-from .shell import ShellResult, classify_command, run_shell
+from .shell import ShellResult, classify_command, iter_process_lines, run_shell, shell_line_subscriber
 from .virtual_fs import VirtualFs
 from .workspace import RunSandbox, prepare_sandbox
 
@@ -9,6 +9,8 @@ __all__ = [
     "ShellResult",
     "VirtualFs",
     "classify_command",
+    "iter_process_lines",
     "prepare_sandbox",
     "run_shell",
+    "shell_line_subscriber",
 ]

--- a/apps/api/ouroboros_api/sandbox/shell.py
+++ b/apps/api/ouroboros_api/sandbox/shell.py
@@ -81,27 +81,32 @@ async def iter_process_lines(proc: asyncio.subprocess.Process) -> AsyncIterator[
     if proc.stdout is None or proc.stderr is None:
         return
 
-    queue: asyncio.Queue[tuple[str, str | None]] = asyncio.Queue()
+    queue: asyncio.Queue[tuple[str, str | None]] = asyncio.Queue(maxsize=1000)
 
     async def _pump(reader: asyncio.StreamReader, stream: str) -> None:
-        while True:
-            line = await reader.readline()
-            if not line:
-                break
-            await queue.put((stream, line.decode("utf-8", errors="replace")))
-        await queue.put((stream, None))
+        try:
+            while True:
+                line = await reader.readline()
+                if not line:
+                    break
+                await queue.put((stream, line.decode("utf-8", errors="replace")))
+        finally:
+            await queue.put((stream, None))
 
     stdout_task = asyncio.create_task(_pump(proc.stdout, "stdout"))
     stderr_task = asyncio.create_task(_pump(proc.stderr, "stderr"))
-    done = 0
-    while done < 2:
-        stream, line = await queue.get()
-        if line is None:
-            done += 1
-            continue
-        yield (stream, line)
-    await stdout_task
-    await stderr_task
+    try:
+        done = 0
+        while done < 2:
+            stream, line = await queue.get()
+            if line is None:
+                done += 1
+                continue
+            yield (stream, line)
+    finally:
+        stdout_task.cancel()
+        stderr_task.cancel()
+        await asyncio.gather(stdout_task, stderr_task, return_exceptions=True)
 
 
 async def _emit_line(sink: LineSink | None, stream: str, line: str) -> None:
@@ -160,7 +165,7 @@ async def run_shell(
         await asyncio.wait_for(_collect_lines(), timeout=timeout)
     except asyncio.TimeoutError:
         proc.kill()
-        await proc.communicate()
+        await proc.wait()
         return ShellResult(
             cmd=cmd,
             classification=classification,

--- a/apps/api/ouroboros_api/sandbox/shell.py
+++ b/apps/api/ouroboros_api/sandbox/shell.py
@@ -3,7 +3,11 @@
 from __future__ import annotations
 
 import asyncio
+import inspect
 import shlex
+from collections.abc import AsyncIterator, Awaitable, Callable, Iterator
+from contextlib import contextmanager
+from contextvars import ContextVar
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -28,6 +32,9 @@ SIDE_EFFECT_PATTERNS = (
 
 BUILD_PATTERNS = ("npm run build", "yarn build", "pnpm build", "uv build", "make build", "cargo build")
 TEST_PATTERNS = ("npm test", "yarn test", "pnpm test", "uv run pytest", "pytest", "make test", "cargo test")
+
+LineSink = Callable[[str, str], Awaitable[None] | None]
+_SHELL_LINE_SINK: ContextVar[LineSink | None] = ContextVar("shell_line_sink", default=None)
 
 
 def classify_command(cmd: str) -> str:
@@ -59,6 +66,52 @@ class ShellResult:
         return not self.blocked and self.exit_code == 0
 
 
+@contextmanager
+def shell_line_subscriber(sink: LineSink) -> Iterator[None]:
+    """Temporarily subscribe to stdout/stderr lines emitted by run_shell."""
+    token = _SHELL_LINE_SINK.set(sink)
+    try:
+        yield
+    finally:
+        _SHELL_LINE_SINK.reset(token)
+
+
+async def iter_process_lines(proc: asyncio.subprocess.Process) -> AsyncIterator[tuple[str, str]]:
+    """Yield process output as (stream, line) tuples in near real-time."""
+    if proc.stdout is None or proc.stderr is None:
+        return
+
+    queue: asyncio.Queue[tuple[str, str | None]] = asyncio.Queue()
+
+    async def _pump(reader: asyncio.StreamReader, stream: str) -> None:
+        while True:
+            line = await reader.readline()
+            if not line:
+                break
+            await queue.put((stream, line.decode("utf-8", errors="replace")))
+        await queue.put((stream, None))
+
+    stdout_task = asyncio.create_task(_pump(proc.stdout, "stdout"))
+    stderr_task = asyncio.create_task(_pump(proc.stderr, "stderr"))
+    done = 0
+    while done < 2:
+        stream, line = await queue.get()
+        if line is None:
+            done += 1
+            continue
+        yield (stream, line)
+    await stdout_task
+    await stderr_task
+
+
+async def _emit_line(sink: LineSink | None, stream: str, line: str) -> None:
+    if sink is None:
+        return
+    maybe_awaitable = sink(stream, line)
+    if inspect.isawaitable(maybe_awaitable):
+        await maybe_awaitable
+
+
 async def run_shell(
     cmd: str,
     *,
@@ -67,6 +120,7 @@ async def run_shell(
     env: dict[str, str] | None = None,
     timeout: float = 600.0,
     allow_side_effect: bool = False,
+    on_line: LineSink | None = None,
 ) -> ShellResult:
     classification = classify_command(cmd)
     if dry_run and classification == "side_effect" and not allow_side_effect:
@@ -89,8 +143,21 @@ async def run_shell(
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.PIPE,
     )
+    sink = on_line or _SHELL_LINE_SINK.get()
+    stdout_parts: list[str] = []
+    stderr_parts: list[str] = []
+
+    async def _collect_lines() -> None:
+        async for stream, line in iter_process_lines(proc):
+            if stream == "stdout":
+                stdout_parts.append(line)
+            else:
+                stderr_parts.append(line)
+            await _emit_line(sink, stream, line)
+        await proc.wait()
+
     try:
-        out, err = await asyncio.wait_for(proc.communicate(), timeout=timeout)
+        await asyncio.wait_for(_collect_lines(), timeout=timeout)
     except asyncio.TimeoutError:
         proc.kill()
         await proc.communicate()
@@ -104,11 +171,19 @@ async def run_shell(
             blocked=True,
             reason="timeout",
         )
+    except asyncio.CancelledError:
+        proc.terminate()
+        try:
+            await asyncio.wait_for(proc.wait(), timeout=2.0)
+        except asyncio.TimeoutError:
+            proc.kill()
+            await proc.wait()
+        raise
     return ShellResult(
         cmd=cmd,
         classification=classification,
         cwd=str(cwd),
         exit_code=proc.returncode or 0,
-        stdout=out.decode("utf-8", errors="replace"),
-        stderr=err.decode("utf-8", errors="replace"),
+        stdout="".join(stdout_parts),
+        stderr="".join(stderr_parts),
     )

--- a/apps/api/pyproject.toml
+++ b/apps/api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ouroboros-api"
-version = "0.1.2"
+version = "0.1.3"
 description = "Ouroboros orchestrator API: agent pipelines, dry-run, MCP, multi-provider LLM routing."
 requires-python = ">=3.12"
 readme = "README.md"

--- a/apps/api/tests/test_dry_run.py
+++ b/apps/api/tests/test_dry_run.py
@@ -9,7 +9,7 @@ from types import SimpleNamespace
 import pytest
 
 from ouroboros_api.orchestrator.dry_run import is_dry_run, step_is_side_effecting
-from ouroboros_api.sandbox.shell import classify_command, run_shell
+from ouroboros_api.sandbox.shell import classify_command, run_shell, shell_line_subscriber
 from ouroboros_api.sandbox.virtual_fs import VirtualFs
 
 
@@ -67,6 +67,40 @@ async def test_run_shell_allows_safe_commands(tmp_repo: Path) -> None:
     assert res.blocked is False
     assert res.exit_code == 0
     assert "README.md" in res.stdout
+
+
+@pytest.mark.asyncio
+async def test_run_shell_streams_lines_to_subscriber(tmp_repo: Path) -> None:
+    seen: list[tuple[str, str]] = []
+
+    async def on_line(stream: str, line: str) -> None:
+        seen.append((stream, line))
+
+    with shell_line_subscriber(on_line):
+        res = await run_shell(
+            'python -c "import sys; print(\'out\', flush=True); print(\'err\', file=sys.stderr, flush=True)"',
+            cwd=tmp_repo,
+            dry_run=False,
+        )
+
+    assert res.succeeded is True
+    assert ("stdout", "out\n") in seen
+    assert ("stderr", "err\n") in seen
+
+
+@pytest.mark.asyncio
+async def test_run_shell_can_be_cancelled(tmp_repo: Path) -> None:
+    task = asyncio.create_task(
+        run_shell(
+            'python -c "import time; time.sleep(30)"',
+            cwd=tmp_repo,
+            dry_run=False,
+        )
+    )
+    await asyncio.sleep(0.1)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await asyncio.wait_for(task, timeout=3.0)
 
 
 def test_virtualfs_overlays_writes(tmp_repo: Path) -> None:

--- a/apps/api/uv.lock
+++ b/apps/api/uv.lock
@@ -986,7 +986,7 @@ wheels = [
 
 [[package]]
 name = "ouroboros-api"
-version = "0.1.2"
+version = "0.1.3"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ouroboros-web",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "private": true,
   "scripts": {
     "dev": "next dev -p 3000",

--- a/apps/web/src/app/runs/[id]/page.tsx
+++ b/apps/web/src/app/runs/[id]/page.tsx
@@ -4,10 +4,11 @@ import { use, useEffect, useMemo, useState } from "react";
 import dynamic from "next/dynamic";
 import { Badge, Box, Button, Dialog, Flex, Tabs, Text, TextField } from "@radix-ui/themes";
 import { PageShell, PageHeader } from "@/components/layout/page-shell";
+import { LogPane } from "@/components/runs/log-pane";
 import { useRun } from "@/lib/api/hooks";
 import { api } from "@/lib/api/client";
 import { useRunStream } from "@/lib/ws/use-run-stream";
-import type { Intervention, Run, RunStep } from "@/lib/api/types";
+import type { Intervention, Run, RunEvent, RunStep } from "@/lib/api/types";
 import { mutate } from "swr";
 
 const PlanFlow = dynamic(() => import("@/components/flow/run-plan-flow").then((m) => m.RunPlanFlow), { ssr: false });
@@ -142,7 +143,7 @@ export default function RunDetailPage({ params }: { params: Promise<{ id: string
           <Tabs.Content value="timeline">
             <Flex direction="column" gap="3">
               {(run?.steps || []).map((step) => (
-                <StepDetail key={step.id} runId={id} step={step} />
+                <StepDetail key={step.id} runId={id} step={step} events={events} />
               ))}
             </Flex>
           </Tabs.Content>
@@ -231,7 +232,7 @@ function StepRow({ step }: { step: RunStep; active: boolean }) {
   );
 }
 
-function StepDetail({ runId, step }: { runId: string; step: RunStep }) {
+function StepDetail({ runId, step, events }: { runId: string; step: RunStep; events: RunEvent[] }) {
   const [artifacts, setArtifacts] = useState<Array<{ id: string; kind: string; name: string; inline_content: string | null }>>([]);
   const [open, setOpen] = useState(false);
 
@@ -256,6 +257,9 @@ function StepDetail({ runId, step }: { runId: string; step: RunStep }) {
           </Button>
         </Flex>
       </Flex>
+      <Box mt="2">
+        <LogPane stepId={step.id} events={events} isRunning={step.status === "running"} />
+      </Box>
       {open && (
         <Flex direction="column" gap="2" mt="2">
           {artifacts.length === 0 ? (

--- a/apps/web/src/app/runs/[id]/page.tsx
+++ b/apps/web/src/app/runs/[id]/page.tsx
@@ -49,11 +49,18 @@ export default function RunDetailPage({ params }: { params: Promise<{ id: string
     };
   }, [id, events.length]);
 
-  const stepEventsById = useMemo(() => {
-    const map = new Map<string, ReturnType<typeof Object> | unknown>();
+  const eventsByStepId = useMemo(() => {
+    const map = new Map<string, RunEvent[]>();
     for (const evt of events) {
       const stepId = (evt.payload?.step_id as string) || "";
-      if (stepId) map.set(stepId, evt);
+      if (stepId) {
+        const arr = map.get(stepId);
+        if (arr) {
+          arr.push(evt);
+        } else {
+          map.set(stepId, [evt]);
+        }
+      }
     }
     return map;
   }, [events]);
@@ -143,7 +150,7 @@ export default function RunDetailPage({ params }: { params: Promise<{ id: string
           <Tabs.Content value="timeline">
             <Flex direction="column" gap="3">
               {(run?.steps || []).map((step) => (
-                <StepDetail key={step.id} runId={id} step={step} events={events} />
+                <StepDetail key={step.id} runId={id} step={step} events={eventsByStepId.get(step.id) || []} />
               ))}
             </Flex>
           </Tabs.Content>
@@ -191,9 +198,6 @@ export default function RunDetailPage({ params }: { params: Promise<{ id: string
           )}
         </Dialog.Content>
       </Dialog.Root>
-
-      {/* avoids lint warning */}
-      {stepEventsById.size > -1 ? null : null}
 
       <_MonacoPreload />
     </PageShell>

--- a/apps/web/src/components/runs/log-pane.test.tsx
+++ b/apps/web/src/components/runs/log-pane.test.tsx
@@ -1,0 +1,76 @@
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { Theme } from "@radix-ui/themes";
+import { LogPane } from "./log-pane";
+import type { RunEvent } from "@/lib/api/types";
+
+declare global {
+  // eslint-disable-next-line no-var
+  var IS_REACT_ACT_ENVIRONMENT: boolean | undefined;
+}
+
+function renderPane(events: RunEvent[], isRunning = true) {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  act(() => {
+    root.render(
+      <Theme>
+        <LogPane stepId="step-1" events={events} isRunning={isRunning} />
+      </Theme>,
+    );
+  });
+  return {
+    container,
+    unmount: () => {
+      act(() => {
+        root.unmount();
+      });
+      container.remove();
+    },
+  };
+}
+
+describe("LogPane", () => {
+  beforeEach(() => {
+    globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+    Object.defineProperty(Element.prototype, "scrollIntoView", {
+      configurable: true,
+      value: vi.fn(),
+      writable: true,
+    });
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = "";
+    vi.restoreAllMocks();
+  });
+
+  it("renders only logs from the matching step", () => {
+    const events: RunEvent[] = [
+      {
+        run_id: "run-1",
+        type: "step.log",
+        payload: { step_id: "step-1", stream: "stdout", line: "hello\n" },
+        timestamp: "2026-04-19T00:00:00Z",
+      },
+      {
+        run_id: "run-1",
+        type: "step.log",
+        payload: { step_id: "step-2", stream: "stderr", line: "ignore\n" },
+        timestamp: "2026-04-19T00:00:01Z",
+      },
+    ];
+    const view = renderPane(events, true);
+    expect(view.container.textContent).toContain("[stdout] hello");
+    expect(view.container.textContent).not.toContain("ignore");
+    view.unmount();
+  });
+
+  it("shows waiting state when running with no logs", () => {
+    const view = renderPane([], true);
+    expect(view.container.textContent).toContain("Waiting for log output");
+    view.unmount();
+  });
+});

--- a/apps/web/src/components/runs/log-pane.tsx
+++ b/apps/web/src/components/runs/log-pane.tsx
@@ -4,6 +4,8 @@ import { useEffect, useMemo, useRef } from "react";
 import { Box, Text } from "@radix-ui/themes";
 import type { RunEvent } from "@/lib/api/types";
 
+const MAX_LOG_LINES = 500;
+
 type LogPaneProps = {
   stepId: string;
   events: RunEvent[];
@@ -11,14 +13,13 @@ type LogPaneProps = {
 };
 
 export function LogPane({ stepId, events, isRunning }: LogPaneProps) {
-  const rows = useMemo(
-    () =>
-      events.filter((evt) => {
-        if (evt.type !== "step.log") return false;
-        return evt.payload?.step_id === stepId && typeof evt.payload?.line === "string";
-      }),
-    [events, stepId],
-  );
+  const rows = useMemo(() => {
+    const filtered = events.filter((evt) => {
+      if (evt.type !== "step.log") return false;
+      return evt.payload?.step_id === stepId && typeof evt.payload?.line === "string";
+    });
+    return filtered.length > MAX_LOG_LINES ? filtered.slice(-MAX_LOG_LINES) : filtered;
+  }, [events, stepId]);
   const endRef = useRef<HTMLDivElement | null>(null);
 
   useEffect(() => {

--- a/apps/web/src/components/runs/log-pane.tsx
+++ b/apps/web/src/components/runs/log-pane.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import { useEffect, useMemo, useRef } from "react";
+import { Box, Text } from "@radix-ui/themes";
+import type { RunEvent } from "@/lib/api/types";
+
+type LogPaneProps = {
+  stepId: string;
+  events: RunEvent[];
+  isRunning: boolean;
+};
+
+export function LogPane({ stepId, events, isRunning }: LogPaneProps) {
+  const rows = useMemo(
+    () =>
+      events.filter((evt) => {
+        if (evt.type !== "step.log") return false;
+        return evt.payload?.step_id === stepId && typeof evt.payload?.line === "string";
+      }),
+    [events, stepId],
+  );
+  const endRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (!isRunning) return;
+    endRef.current?.scrollIntoView({ block: "end" });
+  }, [isRunning, rows.length]);
+
+  return (
+    <Box className="rounded-md border border-[var(--gray-a5)] bg-[var(--gray-a2)] p-2">
+      <Text size="1" color="gray">
+        Live logs
+      </Text>
+      <div className="mt-1 max-h-44 overflow-auto rounded bg-[var(--gray-1)] p-2 font-mono text-xs">
+        {rows.length === 0 ? (
+          <Text size="1" color="gray">
+            {isRunning ? "Waiting for log output..." : "No live logs for this step."}
+          </Text>
+        ) : (
+          rows.map((evt, i) => {
+            const stream = typeof evt.payload.stream === "string" ? evt.payload.stream : "stdout";
+            const line = String(evt.payload.line ?? "");
+            return (
+              <div
+                key={`${evt.timestamp}-${i}`}
+                className={stream === "stderr" ? "text-red-500" : "text-[var(--gray-12)]"}
+              >
+                [{stream}] {line}
+              </div>
+            );
+          })
+        )}
+        <div ref={endRef} />
+      </div>
+    </Box>
+  );
+}

--- a/public/WHATS_NEW.md
+++ b/public/WHATS_NEW.md
@@ -1,5 +1,6 @@
 # What's New
 
+- Added real-time shell step log streaming with per-step live log panes in the run detail timeline.
 - Added system-aware light/dark mode support with a top-right toggle in the web application header.
 - Added a first-run onboarding wizard and workspace onboarding status APIs to guide setup through workspace naming, first project creation, and first provider connection.
 - Added provider health probes with persisted status/error reporting, provider badges, and a dedicated health summary page.


### PR DESCRIPTION
## Summary
- stream shell output line-by-line in `run_shell` via an async iterator and a per-run subscriber hook
- publish `step.log` websocket events from the engine with `step_id`, `stream`, and `line` payloads while steps are running
- add a live per-step log pane in run details, plus targeted API/web tests and roadmap/changelog/version updates for ticket #11

## Test plan
- [x] `yarn build`
- [x] `yarn --cwd apps/api test`
- [x] `yarn --cwd apps/api test tests/test_dry_run.py`
- [x] `yarn --cwd apps/web vitest run src/components/runs/log-pane.test.tsx`
- [ ] `yarn test` *(fails due to pre-existing `apps/web/src/components/onboarding/wizard.test.tsx` timeout unrelated to this ticket)*

## Risk / notes
- `step.log` can emit many events on verbose commands; consumers should continue filtering by `step_id`.
- shell cancellation now terminates in-flight subprocesses to avoid orphaned commands.

Closes #11

Made with [Cursor](https://cursor.com)