### PR TITLE
Fix #13 - resume interrupted runs from persisted snapshots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 2026-04-19
 
+- Added interrupted run recovery with persisted `Run.snapshot_json` context, startup `running -> interrupted` sweep, and a resume API/UI path that skips previously succeeded nodes.
 - Added an `ouroboros init` CLI command that prompts for data directory/DB URL and writes `.env` plus `.env.example` without overwriting existing `.env`.
 - Added README quick-start Step 0 guidance for running `uv run ouroboros init` before local development setup.
 - Added line-by-line shell output streaming via `step.log` run events and surfaced live per-step log panes on the run detail timeline.

--- a/PLANNED_FEATURE_ROADMAP_2026.md
+++ b/PLANNED_FEATURE_ROADMAP_2026.md
@@ -21,6 +21,7 @@ Completed
 - #10 - Added per-language router policy defaults to all seed router agents.
 - #11 - Added real-time stdout/stderr streaming for shell steps with step-level live logs.
 - #12 - Added `ouroboros init` CLI flow to scaffold `.env` / `.env.example` with sensible defaults.
+- #13 - Added interrupted-run snapshots plus resume support so runs can continue after API restarts.
 
 ---
 
@@ -38,7 +39,6 @@ Completed
 | #     | Issue                                                                                          | Tier | Notes                                                    |
 |-------|------------------------------------------------------------------------------------------------|------|----------------------------------------------------------|
 | #8 | Healthcheck panel: ping each configured provider, surface "needs key" / "ollama unreachable"   | MVP  | New `GET /api/providers/{id}/health` and a `/health` page       |
-| #13 | "Resume" button when a run was interrupted by a crash mid-step                                 | MVP  | Engine has `attempts` but no resume from prior step              |
 | #14 | Robust dry-run diff viewer: real side-by-side using Monaco's `DiffEditor`                      | MVP  | Current `DiffViewer` is a thin wrapper; needs left/right inputs  |
 
 ## Stage 2 — UX & power-user features

--- a/apps/api/ouroboros_api/api/runs.py
+++ b/apps/api/ouroboros_api/api/runs.py
@@ -120,6 +120,24 @@ async def cancel_run(
     return {"cancelled": cancelled}
 
 
+@router.post("/{run_id}/resume", response_model=RunOut)
+async def resume_run(
+    run_id: str,
+    ws: Workspace = Depends(workspace),
+    session: AsyncSession = Depends(db_session),
+) -> RunOut:
+    run = await session.get(Run, run_id)
+    if not run or run.workspace_id != ws.id:
+        raise HTTPException(404, "Run not found")
+    if run.status != "interrupted":
+        raise HTTPException(400, "Only interrupted runs can be resumed")
+    if run_manager.is_running(run.id):
+        raise HTTPException(409, "Run is already active")
+    await run_manager.resume(run.id)
+    await session.refresh(run)
+    return RunOut.model_validate(run)
+
+
 @router.post("/{run_id}/retry", response_model=RunOut)
 async def retry_run(
     run_id: str,

--- a/apps/api/ouroboros_api/api/runs.py
+++ b/apps/api/ouroboros_api/api/runs.py
@@ -120,7 +120,7 @@ async def cancel_run(
     return {"cancelled": cancelled}
 
 
-@router.post("/{run_id}/resume", response_model=RunOut)
+@router.post("/{run_id}/resume", response_model=RunOut, status_code=202)
 async def resume_run(
     run_id: str,
     ws: Workspace = Depends(workspace),
@@ -133,8 +133,11 @@ async def resume_run(
         raise HTTPException(400, "Only interrupted runs can be resumed")
     if run_manager.is_running(run.id):
         raise HTTPException(409, "Run is already active")
-    await run_manager.resume(run.id)
+    run.status = "running"
+    run.finished_at = None
+    await session.commit()
     await session.refresh(run)
+    await run_manager.resume(run.id)
     return RunOut.model_validate(run)
 
 

--- a/apps/api/ouroboros_api/db/migrations/versions/0005_run_snapshot_and_interrupted_status.py
+++ b/apps/api/ouroboros_api/db/migrations/versions/0005_run_snapshot_and_interrupted_status.py
@@ -1,0 +1,29 @@
+"""add run snapshot json column
+
+Revision ID: 0005_run_snapshot_and_interrupted_status
+Revises: 0004_seed_agent_router_language_hints
+Create Date: 2026-04-20
+
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0005_run_snapshot_and_interrupted_status"
+down_revision = "0004_seed_agent_router_language_hints"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("runs") as batch_op:
+        batch_op.add_column(
+            sa.Column("snapshot_json", sa.JSON(), nullable=False, server_default=sa.text("'{}'"))
+        )
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("runs") as batch_op:
+        batch_op.drop_column("snapshot_json")

--- a/apps/api/ouroboros_api/db/models.py
+++ b/apps/api/ouroboros_api/db/models.py
@@ -227,6 +227,7 @@ class Run(Base, TimestampMixin):
     total_tokens_out: Mapped[int] = mapped_column(Integer, default=0, nullable=False)
     cost_estimate_usd: Mapped[float] = mapped_column(Float, default=0.0, nullable=False)
     override_models: Mapped[dict[str, Any]] = mapped_column(JSON, default=dict)
+    snapshot_json: Mapped[dict[str, Any]] = mapped_column(JSON, default=dict)
     plan: Mapped[dict[str, Any]] = mapped_column(JSON, default=dict)
     error: Mapped[str | None] = mapped_column(Text)
     sandbox_path: Mapped[str | None] = mapped_column(String(500))

--- a/apps/api/ouroboros_api/main.py
+++ b/apps/api/ouroboros_api/main.py
@@ -21,7 +21,8 @@ from .api import (
     ws,
 )
 from .config import settings
-from .db.session import init_db
+from .db.session import SessionLocal, init_db
+from .orchestrator.engine import interrupt_in_flight_runs
 
 logging.basicConfig(level=settings.log_level)
 log = logging.getLogger("ouroboros")
@@ -31,6 +32,10 @@ log = logging.getLogger("ouroboros")
 async def lifespan(app: FastAPI):
     settings.ensure_dirs()
     await init_db()
+    async with SessionLocal() as session:
+        interrupted = await interrupt_in_flight_runs(session)
+    if interrupted:
+        log.info("marked %s in-flight runs as interrupted at startup", interrupted)
     log.info("ouroboros api ready (data_dir=%s)", settings.data_dir)
     yield
 

--- a/apps/api/ouroboros_api/orchestrator/engine.py
+++ b/apps/api/ouroboros_api/orchestrator/engine.py
@@ -8,7 +8,7 @@ import logging
 from datetime import UTC, datetime
 from typing import Any
 
-from sqlalchemy import select
+from sqlalchemy import func, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from ..adapters.base import ResolvedModel, StepResult
@@ -503,19 +503,22 @@ def _snapshot_from_context(ctx: RunContext, run: Run) -> dict[str, Any]:
 
 async def interrupt_in_flight_runs(session: AsyncSession) -> int:
     now = datetime.now(UTC)
-    runs = list((await session.execute(select(Run).where(Run.status == "running"))).scalars())
-    for run in runs:
-        run.status = "interrupted"
-        if not run.finished_at:
-            run.finished_at = now
-    steps = list((await session.execute(select(RunStep).where(RunStep.status == "running"))).scalars())
-    for step in steps:
-        step.status = "interrupted"
-        if not step.finished_at:
-            step.finished_at = now
-    if runs or steps:
+    run_result = await session.execute(
+        update(Run)
+        .where(Run.status == "running")
+        .values(status="interrupted", finished_at=func.coalesce(Run.finished_at, now))
+        .execution_options(synchronize_session=False)
+    )
+    step_result = await session.execute(
+        update(RunStep)
+        .where(RunStep.status == "running")
+        .values(status="interrupted", finished_at=func.coalesce(RunStep.finished_at, now))
+        .execution_options(synchronize_session=False)
+    )
+    interrupted_count = run_result.rowcount
+    if interrupted_count or step_result.rowcount:
         await session.commit()
-    return len(runs)
+    return interrupted_count
 
 
 run_manager = RunEngine()

--- a/apps/api/ouroboros_api/orchestrator/engine.py
+++ b/apps/api/ouroboros_api/orchestrator/engine.py
@@ -50,7 +50,13 @@ class RunEngine:
     async def start(self, run_id: str) -> None:
         if self.is_running(run_id):
             return
-        task = asyncio.create_task(self._safe_execute(run_id), name=f"run:{run_id}")
+        task = asyncio.create_task(self._safe_execute(run_id, resume=False), name=f"run:{run_id}")
+        self._tasks[run_id] = task
+
+    async def resume(self, run_id: str) -> None:
+        if self.is_running(run_id):
+            return
+        task = asyncio.create_task(self._safe_execute(run_id, resume=True), name=f"run:{run_id}")
         self._tasks[run_id] = task
 
     async def cancel(self, run_id: str) -> bool:
@@ -60,9 +66,9 @@ class RunEngine:
             return True
         return False
 
-    async def _safe_execute(self, run_id: str) -> None:
+    async def _safe_execute(self, run_id: str, *, resume: bool) -> None:
         try:
-            await self._execute(run_id)
+            await self._execute(run_id, resume=resume)
         except Exception as exc:
             log.exception("run %s failed at top level", run_id)
             await bus.publish(RunEvent(run_id=run_id, type="run.failed", payload={"error": str(exc)}))
@@ -74,7 +80,7 @@ class RunEngine:
                     run.finished_at = datetime.now(UTC)
                     await session.commit()
 
-    async def _execute(self, run_id: str) -> None:
+    async def _execute(self, run_id: str, *, resume: bool = False) -> None:
         async with SessionLocal() as session:
             run = await session.get(Run, run_id)
             if not run:
@@ -101,8 +107,12 @@ class RunEngine:
             )
             agents_by_role = {a.role: a for a in agents_list}
 
+            if run.status == "succeeded":
+                return
             run.status = "running"
-            run.started_at = datetime.now(UTC)
+            if not run.started_at:
+                run.started_at = datetime.now(UTC)
+            run.finished_at = None
             await session.commit()
 
             await bus.publish(RunEvent(run_id=run.id, type="run.started", payload={"dry_run": run.dry_run}))
@@ -129,6 +139,7 @@ class RunEngine:
                 project=project,
                 run=run,
             )
+            _restore_context_from_snapshot(ctx, run.snapshot_json if resume else None)
 
             graph = flow.graph or {}
             nodes_by_id = {n["id"]: n for n in graph.get("nodes", [])}
@@ -136,13 +147,34 @@ class RunEngine:
             execution_order = _topological_order(graph)
 
             run.plan = {"nodes": graph.get("nodes", []), "edges": edges}
+            run.snapshot_json = _snapshot_from_context(ctx, run)
             await session.commit()
             await bus.publish(RunEvent(run_id=run.id, type="plan.ready", payload=run.plan))
 
-            sequence = 0
+            existing_steps = list(
+                (
+                    await session.execute(select(RunStep).where(RunStep.run_id == run.id).order_by(RunStep.sequence))
+                ).scalars()
+            )
+            if resume:
+                for step in existing_steps:
+                    if step.status == "running":
+                        step.status = "interrupted"
+                        if not step.finished_at:
+                            step.finished_at = datetime.now(UTC)
+                await session.commit()
+
+            sequence = max((s.sequence for s in existing_steps), default=0)
             attempts: dict[str, int] = {}
+            completed_node_ids = {
+                step.node_id for step in existing_steps if step.status == "succeeded"
+            }
+            for step in existing_steps:
+                attempts[step.node_id] = max(attempts.get(step.node_id, 0), step.attempt)
 
             for node_id in execution_order:
+                if node_id in completed_node_ids:
+                    continue
                 node = nodes_by_id[node_id]
                 attempts[node_id] = attempts.get(node_id, 0) + 1
                 sequence += 1
@@ -161,6 +193,7 @@ class RunEngine:
 
             run.status = "succeeded"
             run.finished_at = datetime.now(UTC)
+            run.snapshot_json = _snapshot_from_context(ctx, run)
             await session.commit()
             await bus.publish(RunEvent(run_id=run.id, type="run.finished", payload={"status": "succeeded"}))
 
@@ -211,12 +244,10 @@ class RunEngine:
         if node_type == "wait_for_user":
             answer = await self._wait_for_user(session, run, step, node)
             ctx.scratchpad.setdefault("interventions", []).append({"node": node_id, "answer": answer})
-            return await self._finish_step(session, run, step, StepResult(summary="user input received"))
+            return await self._finish_step(session, run, step, StepResult(summary="user input received"), ctx)
 
         if node_type != "agent":
-            return await self._finish_step(
-                session, run, step, StepResult(summary=f"node type {node_type!r} ignored")
-            )
+            return await self._finish_step(session, run, step, StepResult(summary=f"node type {node_type!r} ignored"), ctx)
 
         if not agent:
             return await self._finish_step(
@@ -224,6 +255,7 @@ class RunEngine:
                 run,
                 step,
                 StepResult(summary=f"agent for role {node.get('agent_role')!r} not found", failed=True, error="missing agent"),
+                ctx,
             )
 
         provider_model = pick_model(
@@ -235,6 +267,7 @@ class RunEngine:
                 run,
                 step,
                 StepResult(summary="no provider/model available", failed=True, error="no usable provider"),
+                ctx,
             )
         provider = provider_model[0] if provider_model else None
         chosen_model = provider_model[1] if provider_model else None
@@ -253,7 +286,7 @@ class RunEngine:
             adapter = adapters().get(agent.execution_adapter)
         except KeyError as exc:
             return await self._finish_step(
-                session, run, step, StepResult(summary="bad adapter", failed=True, error=str(exc))
+                session, run, step, StepResult(summary="bad adapter", failed=True, error=str(exc)), ctx
             )
 
         async def _publish_step_log(stream: str, line: str) -> None:
@@ -281,7 +314,9 @@ class RunEngine:
                 chosen_model.output_cost_per_mtok,
             )
 
-        ok = await self._finish_step(session, run, step, result, provider_id=resolved.provider_id or None)
+        ok = await self._finish_step(
+            session, run, step, result, ctx, provider_id=resolved.provider_id or None
+        )
         if not ok and attempt < MAX_STEP_RETRIES and (agent.config or {}).get("retry_on_failure", True):
             await bus.publish(
                 RunEvent(run_id=run.id, type="step.retry", payload={"node_id": node_id, "attempt": attempt + 1})
@@ -306,6 +341,7 @@ class RunEngine:
         run: Run,
         step: RunStep,
         result: StepResult,
+        ctx: RunContext,
         *,
         provider_id: str | None = None,
     ) -> bool:
@@ -335,6 +371,7 @@ class RunEngine:
         run.total_tokens_in += result.tokens_in
         run.total_tokens_out += result.tokens_out
         run.cost_estimate_usd += result.cost_usd
+        run.snapshot_json = _snapshot_from_context(ctx, run)
         await session.commit()
 
         await bus.publish(
@@ -368,6 +405,7 @@ class RunEngine:
             run.status = "failed"
             run.error = result.error
             run.finished_at = datetime.now(UTC)
+            run.snapshot_json = _snapshot_from_context(ctx, run)
             await session.commit()
             await bus.publish(
                 RunEvent(run_id=run.id, type="run.failed", payload={"error": result.error, "node_id": step.node_id})
@@ -443,6 +481,41 @@ def _topological_order(graph: dict[str, Any]) -> list[str]:
         if n not in order:
             order.append(n)
     return order
+
+
+def _restore_context_from_snapshot(ctx: RunContext, snapshot: dict[str, Any] | None) -> None:
+    payload = snapshot or {}
+    issue = payload.get("issue")
+    scratchpad = payload.get("scratchpad")
+    if isinstance(issue, dict):
+        ctx.issue = issue
+    if isinstance(scratchpad, dict):
+        ctx.scratchpad = dict(scratchpad)
+
+
+def _snapshot_from_context(ctx: RunContext, run: Run) -> dict[str, Any]:
+    return {
+        "issue": ctx.issue or {},
+        "scratchpad": ctx.scratchpad,
+        "override_models": run.override_models or {},
+    }
+
+
+async def interrupt_in_flight_runs(session: AsyncSession) -> int:
+    now = datetime.now(UTC)
+    runs = list((await session.execute(select(Run).where(Run.status == "running"))).scalars())
+    for run in runs:
+        run.status = "interrupted"
+        if not run.finished_at:
+            run.finished_at = now
+    steps = list((await session.execute(select(RunStep).where(RunStep.status == "running"))).scalars())
+    for step in steps:
+        step.status = "interrupted"
+        if not step.finished_at:
+            step.finished_at = now
+    if runs or steps:
+        await session.commit()
+    return len(runs)
 
 
 run_manager = RunEngine()

--- a/apps/api/pyproject.toml
+++ b/apps/api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ouroboros-api"
-version = "0.1.4"
+version = "0.1.5"
 description = "Ouroboros orchestrator API: agent pipelines, dry-run, MCP, multi-provider LLM routing."
 requires-python = ">=3.12"
 readme = "README.md"

--- a/apps/api/tests/test_runs_resume.py
+++ b/apps/api/tests/test_runs_resume.py
@@ -1,0 +1,217 @@
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from ouroboros_api.api import deps
+from ouroboros_api.db.models import Base, Flow, Project, Run, RunStep, Workspace
+from ouroboros_api.main import create_app
+from ouroboros_api.orchestrator.engine import RunEngine, interrupt_in_flight_runs
+
+
+@pytest_asyncio.fixture
+async def app_and_session(
+    tmp_path: Path,
+) -> AsyncIterator[tuple[object, async_sessionmaker[AsyncSession]]]:
+    db_path = tmp_path / "runs-resume.sqlite"
+    engine = create_async_engine(
+        f"sqlite+aiosqlite:///{db_path}",
+        connect_args={"check_same_thread": False},
+    )
+    session_factory = async_sessionmaker(engine, expire_on_commit=False, class_=AsyncSession)
+
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+    async with session_factory() as session:
+        session.add(Workspace(slug="default", name="Default Workspace"))
+        await session.commit()
+
+    app = create_app()
+
+    @asynccontextmanager
+    async def noop_lifespan(_app: object) -> AsyncIterator[None]:
+        yield
+
+    app.router.lifespan_context = noop_lifespan  # type: ignore[method-assign]
+
+    async def override_db_session() -> AsyncIterator[AsyncSession]:
+        async with session_factory() as session:
+            yield session
+
+    app.dependency_overrides[deps.db_session] = override_db_session
+    try:
+        yield app, session_factory
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+async def _seed_run(
+    session: AsyncSession,
+    *,
+    status: str,
+    graph: dict | None = None,
+    snapshot_json: dict | None = None,
+) -> Run:
+    ws = (await session.execute(select(Workspace).where(Workspace.slug == "default"))).scalar_one()
+    project = Project(
+        workspace_id=ws.id,
+        name="Demo",
+        repo_url="https://github.com/acme/demo",
+        scm_kind="github",
+        default_branch="main",
+    )
+    flow = Flow(
+        workspace_id=ws.id,
+        name="Flow",
+        graph=graph
+        or {
+            "nodes": [{"id": "a", "type": "noop"}, {"id": "b", "type": "noop"}, {"id": "c", "type": "noop"}],
+            "edges": [{"source": "a", "target": "b"}, {"source": "b", "target": "c"}],
+        },
+        is_default=True,
+    )
+    session.add_all([project, flow])
+    await session.flush()
+    run = Run(
+        workspace_id=ws.id,
+        project_id=project.id,
+        flow_id=flow.id,
+        title="Resume run",
+        status=status,
+        dry_run=True,
+        snapshot_json=snapshot_json or {},
+    )
+    session.add(run)
+    await session.commit()
+    await session.refresh(run)
+    return run
+
+
+@pytest.mark.asyncio
+async def test_resume_endpoint_starts_resume_task_for_interrupted_run(
+    app_and_session: tuple[object, async_sessionmaker[AsyncSession]],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    app, session_factory = app_and_session
+    async with session_factory() as session:
+        run = await _seed_run(session, status="interrupted")
+
+    called: list[str] = []
+
+    async def fake_resume(run_id: str) -> None:
+        called.append(run_id)
+
+    monkeypatch.setattr("ouroboros_api.api.runs.run_manager.resume", fake_resume)
+    monkeypatch.setattr("ouroboros_api.api.runs.run_manager.is_running", lambda _run_id: False)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        res = await client.post(f"/api/runs/{run.id}/resume")
+
+    assert res.status_code == 200
+    assert called == [run.id]
+
+
+@pytest.mark.asyncio
+async def test_resume_endpoint_rejects_non_interrupted_run(
+    app_and_session: tuple[object, async_sessionmaker[AsyncSession]],
+) -> None:
+    app, session_factory = app_and_session
+    async with session_factory() as session:
+        run = await _seed_run(session, status="failed")
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        res = await client.post(f"/api/runs/{run.id}/resume")
+
+    assert res.status_code == 400
+    assert "interrupted" in res.text
+
+
+@pytest.mark.asyncio
+async def test_interrupt_in_flight_runs_marks_runs_and_steps_interrupted(
+    app_and_session: tuple[object, async_sessionmaker[AsyncSession]],
+) -> None:
+    _, session_factory = app_and_session
+    async with session_factory() as session:
+        run = await _seed_run(session, status="running")
+        session.add(
+            RunStep(
+                workspace_id=run.workspace_id,
+                run_id=run.id,
+                node_id="a",
+                sequence=1,
+                attempt=1,
+                status="running",
+                dry_run=True,
+            )
+        )
+        await session.commit()
+        count = await interrupt_in_flight_runs(session)
+        assert count == 1
+
+    async with session_factory() as session:
+        updated_run = await session.get(Run, run.id)
+        assert updated_run is not None
+        assert updated_run.status == "interrupted"
+        updated_step = (
+            await session.execute(select(RunStep).where(RunStep.run_id == run.id))
+        ).scalar_one()
+        assert updated_step.status == "interrupted"
+
+
+@pytest.mark.asyncio
+async def test_engine_resume_skips_previously_succeeded_nodes(
+    app_and_session: tuple[object, async_sessionmaker[AsyncSession]],
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    _, session_factory = app_and_session
+    async with session_factory() as session:
+        run = await _seed_run(
+            session,
+            status="interrupted",
+            snapshot_json={"scratchpad": {"branch": "ticket-13"}, "issue": {"number": 13}},
+        )
+        session.add(
+            RunStep(
+                workspace_id=run.workspace_id,
+                run_id=run.id,
+                node_id="a",
+                sequence=1,
+                attempt=1,
+                status="succeeded",
+                dry_run=True,
+            )
+        )
+        await session.commit()
+
+    async def fake_prepare_sandbox(_run_id: str, _repo_url: str, _default_branch: str) -> SimpleNamespace:
+        return SimpleNamespace(repo_path=tmp_path)
+
+    monkeypatch.setattr("ouroboros_api.orchestrator.engine.prepare_sandbox", fake_prepare_sandbox)
+    monkeypatch.setattr("ouroboros_api.orchestrator.engine.SessionLocal", session_factory)
+
+    engine = RunEngine()
+    await engine._execute(run.id, resume=True)
+
+    async with session_factory() as session:
+        steps = list(
+            (
+                await session.execute(select(RunStep).where(RunStep.run_id == run.id).order_by(RunStep.sequence))
+            ).scalars()
+        )
+        assert [s.node_id for s in steps] == ["a", "b", "c"]
+        assert [s.status for s in steps] == ["succeeded", "succeeded", "succeeded"]
+        updated_run = await session.get(Run, run.id)
+        assert updated_run is not None
+        assert updated_run.status == "succeeded"
+        assert updated_run.snapshot_json.get("scratchpad", {}).get("branch") == "ticket-13"

--- a/apps/api/tests/test_runs_resume.py
+++ b/apps/api/tests/test_runs_resume.py
@@ -117,7 +117,7 @@ async def test_resume_endpoint_starts_resume_task_for_interrupted_run(
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
         res = await client.post(f"/api/runs/{run.id}/resume")
 
-    assert res.status_code == 200
+    assert res.status_code == 202
     assert called == [run.id]
 
 

--- a/apps/api/uv.lock
+++ b/apps/api/uv.lock
@@ -986,7 +986,7 @@ wheels = [
 
 [[package]]
 name = "ouroboros-api"
-version = "0.1.4"
+version = "0.1.5"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ouroboros-web",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "private": true,
   "scripts": {
     "dev": "next dev -p 3000",

--- a/apps/web/src/app/runs/[id]/page.tsx
+++ b/apps/web/src/app/runs/[id]/page.tsx
@@ -17,6 +17,7 @@ const MonacoDiff = dynamic(() => import("@/components/editors/diff-viewer").then
 const STATUS_COLOR: Record<string, "gray" | "iris" | "green" | "red" | "amber"> = {
   pending: "gray",
   running: "iris",
+  interrupted: "amber",
   succeeded: "green",
   failed: "red",
   cancelled: "amber",
@@ -75,6 +76,12 @@ export default function RunDetailPage({ params }: { params: Promise<{ id: string
     window.location.href = `/runs/${fresh.id}`;
   };
 
+  const resume = async () => {
+    await api.post<Run>(`/api/runs/${id}/resume`);
+    await mutate(`/api/runs/${id}`);
+    await mutate("/api/runs");
+  };
+
   const submitIntervention = async () => {
     if (!intervention) return;
     await api.post(`/api/runs/${id}/interventions/${intervention.id}`, { answer: { text: answer } });
@@ -107,6 +114,9 @@ export default function RunDetailPage({ params }: { params: Promise<{ id: string
             <Flex gap="2">
               {run.status === "running" ? (
                 <Button color="amber" variant="soft" onClick={cancel}>Cancel</Button>
+              ) : null}
+              {run.status === "interrupted" ? (
+                <Button color="amber" onClick={resume}>Resume</Button>
               ) : null}
               <Button
                 variant="soft"

--- a/apps/web/src/app/runs/page.tsx
+++ b/apps/web/src/app/runs/page.tsx
@@ -11,6 +11,7 @@ import type { Run } from "@/lib/api/types";
 const STATUS_COLORS: Record<string, "gray" | "green" | "red" | "amber" | "iris"> = {
   pending: "gray",
   running: "iris",
+  interrupted: "amber",
   succeeded: "green",
   failed: "red",
   cancelled: "amber",

--- a/apps/web/src/lib/api/types.ts
+++ b/apps/web/src/lib/api/types.ts
@@ -200,7 +200,7 @@ export type RunStep = {
   agent_id: string | null;
   sequence: number;
   attempt: number;
-  status: "pending" | "running" | "succeeded" | "failed" | "cancelled" | string;
+  status: "pending" | "running" | "interrupted" | "succeeded" | "failed" | "cancelled" | string;
   started_at: string | null;
   finished_at: string | null;
   provider_id: string | null;
@@ -221,7 +221,7 @@ export type Run = {
   issue_id: string | null;
   issue_number: number | null;
   title: string;
-  status: "pending" | "running" | "succeeded" | "failed" | "cancelled" | string;
+  status: "pending" | "running" | "interrupted" | "succeeded" | "failed" | "cancelled" | string;
   dry_run: boolean;
   started_at: string | null;
   finished_at: string | null;

--- a/public/WHATS_NEW.md
+++ b/public/WHATS_NEW.md
@@ -1,5 +1,6 @@
 # What's New
 
+- Added interrupted-run recovery with persisted run snapshots, automatic startup sweep from `running` to `interrupted`, and a Resume action in run details to continue from the first unfinished step.
 - Added `ouroboros init` to scaffold `.env` and `.env.example` with default `OUROBOROS_DATA_DIR` and `OUROBOROS_DB_URL` values for first-run setup.
 - Added real-time shell step log streaming with per-step live log panes in the run detail timeline.
 - Added system-aware light/dark mode support with a top-right toggle in the web application header.


### PR DESCRIPTION
## Summary
- persist run context snapshots (`issue`, `scratchpad`, `override_models`) into `Run.snapshot_json` after each step and add migration `0005_run_snapshot_and_interrupted_status`
- mark startup in-flight runs/steps as `interrupted`, add `POST /api/runs/{id}/resume`, and resume execution from the first non-succeeded node while preserving dry-run behavior
- add Resume UI action/state handling in run pages, plus roadmap/changelog/what's-new updates and coverage in `test_runs_resume.py`

## Test plan
- [x] `yarn build`
- [x] `yarn workspace @ouroboros/api test`
- [ ] `yarn workspace ouroboros-web test` *(fails on existing onboarding wizard flake: `OnboardingWizard > can be skipped and resurfaces on a new load` timing out on "Name your workspace")*

## Risk / notes
- Resume now always provisions a sandbox before continuing; failures there still transition the run to `failed`.
- Existing untracked local directory `apps/api/data/` is intentionally excluded from this PR.

Fixes #13

Made with [Cursor](https://cursor.com)