### PR TITLE
Fix #14 - true side-by-side dry-run diff viewer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2026-04-20
+
+- Added true Monaco `DiffEditor` dry-run file diffs using sandbox originals and artifact proposed content, with a per-view side-by-side/unified toggle.
+- Added `GET /api/runs/{id}/sandbox-file?path=...` with sandbox path traversal protection and tests for both valid reads and `../../etc/passwd` rejection.
+
 ## 2026-04-19
 
 - Added interrupted run recovery with persisted `Run.snapshot_json` context, startup `running -> interrupted` sweep, and a resume API/UI path that skips previously succeeded nodes.

--- a/PLANNED_FEATURE_ROADMAP_2026.md
+++ b/PLANNED_FEATURE_ROADMAP_2026.md
@@ -22,6 +22,7 @@ Completed
 - #11 - Added real-time stdout/stderr streaming for shell steps with step-level live logs.
 - #12 - Added `ouroboros init` CLI flow to scaffold `.env` / `.env.example` with sensible defaults.
 - #13 - Added interrupted-run snapshots plus resume support so runs can continue after API restarts.
+- #14 - Added true dry-run file diff viewing with Monaco `DiffEditor`, sandbox original-file reads, and side-by-side/unified mode toggle.
 
 ---
 
@@ -39,7 +40,6 @@ Completed
 | #     | Issue                                                                                          | Tier | Notes                                                    |
 |-------|------------------------------------------------------------------------------------------------|------|----------------------------------------------------------|
 | #8 | Healthcheck panel: ping each configured provider, surface "needs key" / "ollama unreachable"   | MVP  | New `GET /api/providers/{id}/health` and a `/health` page       |
-| #14 | Robust dry-run diff viewer: real side-by-side using Monaco's `DiffEditor`                      | MVP  | Current `DiffViewer` is a thin wrapper; needs left/right inputs  |
 
 ## Stage 2 — UX & power-user features
 

--- a/apps/api/ouroboros_api/adapters/agents/_llm_loop.py
+++ b/apps/api/ouroboros_api/adapters/agents/_llm_loop.py
@@ -10,6 +10,7 @@ from ..base import LLMMessage, ProviderRegistry, ResolvedModel, StepResult
 from ..tools import TOOL_SCHEMAS, ToolContext, invoke_tool
 
 MAX_TOOL_TURNS = 12
+_MAX_FILE_DIFF_CHARS = 20_000
 
 
 def _format_finish(result: dict[str, Any]) -> tuple[str, dict[str, Any]]:
@@ -98,12 +99,19 @@ async def llm_agent_loop(
 
     if ctx.dry_run:
         for change in ctx.vfs.list_changes():
+            raw_content = change.get("content", "")
+            truncated = len(raw_content) > _MAX_FILE_DIFF_CHARS
+            inline = raw_content[-_MAX_FILE_DIFF_CHARS:] if truncated else raw_content
             artifacts.append(
                 {
                     "kind": "file_diff",
                     "name": change["path"],
-                    "inline_content": change.get("content", ""),
-                    "meta": {"kind": change["kind"], "path": change["path"]},
+                    "inline_content": inline,
+                    "meta": {
+                        "kind": change["kind"],
+                        "path": change["path"],
+                        "truncated": truncated,
+                    },
                 }
             )
 

--- a/apps/api/ouroboros_api/adapters/agents/_llm_loop.py
+++ b/apps/api/ouroboros_api/adapters/agents/_llm_loop.py
@@ -102,8 +102,8 @@ async def llm_agent_loop(
                 {
                     "kind": "file_diff",
                     "name": change["path"],
-                    "inline_content": change["diff"],
-                    "meta": {"kind": change["kind"]},
+                    "inline_content": change.get("content", ""),
+                    "meta": {"kind": change["kind"], "path": change["path"]},
                 }
             )
 

--- a/apps/api/ouroboros_api/api/runs.py
+++ b/apps/api/ouroboros_api/api/runs.py
@@ -6,6 +6,7 @@ import json
 from datetime import UTC, datetime
 from pathlib import Path
 
+import anyio
 from fastapi import APIRouter, Depends, HTTPException
 from fastapi.responses import JSONResponse, PlainTextResponse
 from sqlalchemy import select
@@ -314,7 +315,9 @@ async def sandbox_file(
     if not target.exists() or not target.is_file():
         raise HTTPException(404, "File not found in sandbox")
     try:
-        content = target.read_text(encoding="utf-8")
+        content = await anyio.to_thread.run_sync(
+            lambda: target.read_text(encoding="utf-8")
+        )
     except UnicodeDecodeError as exc:
         raise HTTPException(400, "File is not valid UTF-8 text") from exc
     return {"path": path, "content": content}

--- a/apps/api/ouroboros_api/api/runs.py
+++ b/apps/api/ouroboros_api/api/runs.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 from datetime import UTC, datetime
+from pathlib import Path
 
 from fastapi import APIRouter, Depends, HTTPException
 from fastapi.responses import JSONResponse, PlainTextResponse
@@ -25,6 +26,21 @@ from .schemas import (
 )
 
 router = APIRouter(prefix="/api/runs", tags=["runs"])
+
+
+def _resolve_sandbox_file_path(run: Run, rel_path: str) -> Path:
+    if not rel_path or not rel_path.strip():
+        raise HTTPException(400, "path is required")
+    if not run.sandbox_path:
+        raise HTTPException(404, "Sandbox is not available for this run")
+
+    sandbox_root = Path(run.sandbox_path).resolve()
+    target = (sandbox_root / rel_path).resolve()
+    try:
+        target.relative_to(sandbox_root)
+    except ValueError as exc:
+        raise HTTPException(400, "path escapes sandbox") from exc
+    return target
 
 
 @router.get("", response_model=list[RunOut])
@@ -284,6 +300,26 @@ async def summary_markdown(
     return PlainTextResponse("\n".join(lines))
 
 
+@router.get("/{run_id}/sandbox-file")
+async def sandbox_file(
+    run_id: str,
+    path: str,
+    ws: Workspace = Depends(workspace),
+    session: AsyncSession = Depends(db_session),
+) -> dict[str, str]:
+    run = await session.get(Run, run_id)
+    if not run or run.workspace_id != ws.id:
+        raise HTTPException(404, "Run not found")
+    target = _resolve_sandbox_file_path(run, path)
+    if not target.exists() or not target.is_file():
+        raise HTTPException(404, "File not found in sandbox")
+    try:
+        content = target.read_text(encoding="utf-8")
+    except UnicodeDecodeError as exc:
+        raise HTTPException(400, "File is not valid UTF-8 text") from exc
+    return {"path": path, "content": content}
+
+
 @router.get("/{run_id}/audit")
 async def run_audit(
     run_id: str,
@@ -358,6 +394,7 @@ async def step_artifacts(
             "inline_content": a.inline_content,
             "content_ref": a.content_ref,
             "meta": a.meta,
+            "path": (a.meta or {}).get("path") or (a.name if a.kind == "file_diff" else None),
             "created_at": a.created_at.isoformat() if a.created_at else None,
         }
         for a in res.scalars()

--- a/apps/api/ouroboros_api/sandbox/virtual_fs.py
+++ b/apps/api/ouroboros_api/sandbox/virtual_fs.py
@@ -51,7 +51,14 @@ class VirtualFs:
                     tofile=f"b/{rel}",
                 )
             )
-            changes.append({"path": rel, "kind": "modified" if path.exists() else "added", "diff": diff})
+            changes.append(
+                {
+                    "path": rel,
+                    "kind": "modified" if path.exists() else "added",
+                    "diff": diff,
+                    "content": content,
+                }
+            )
         for rel in self._deleted:
-            changes.append({"path": rel, "kind": "deleted", "diff": ""})
+            changes.append({"path": rel, "kind": "deleted", "diff": "", "content": ""})
         return changes

--- a/apps/api/pyproject.toml
+++ b/apps/api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ouroboros-api"
-version = "0.1.5"
+version = "0.1.6"
 description = "Ouroboros orchestrator API: agent pipelines, dry-run, MCP, multi-provider LLM routing."
 requires-python = ">=3.12"
 readme = "README.md"

--- a/apps/api/tests/test_runs_sandbox_file.py
+++ b/apps/api/tests/test_runs_sandbox_file.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from pathlib import Path
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from ouroboros_api.api import deps
+from ouroboros_api.db.models import Base, Flow, Project, Run, Workspace
+from ouroboros_api.main import create_app
+
+
+@pytest_asyncio.fixture
+async def app_and_session(
+    tmp_path: Path,
+) -> AsyncIterator[tuple[object, async_sessionmaker[AsyncSession], Path]]:
+    db_path = tmp_path / "runs-sandbox-file.sqlite"
+    engine = create_async_engine(
+        f"sqlite+aiosqlite:///{db_path}",
+        connect_args={"check_same_thread": False},
+    )
+    session_factory = async_sessionmaker(engine, expire_on_commit=False, class_=AsyncSession)
+
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+    async with session_factory() as session:
+        session.add(Workspace(slug="default", name="Default Workspace"))
+        await session.commit()
+
+    app = create_app()
+
+    @asynccontextmanager
+    async def noop_lifespan(_app: object) -> AsyncIterator[None]:
+        yield
+
+    app.router.lifespan_context = noop_lifespan  # type: ignore[method-assign]
+
+    async def override_db_session() -> AsyncIterator[AsyncSession]:
+        async with session_factory() as session:
+            yield session
+
+    app.dependency_overrides[deps.db_session] = override_db_session
+    try:
+        yield app, session_factory, tmp_path
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+async def _seed_run(session: AsyncSession, sandbox_path: Path) -> Run:
+    ws = (await session.execute(select(Workspace).where(Workspace.slug == "default"))).scalar_one()
+    project = Project(
+        workspace_id=ws.id,
+        name="Demo",
+        repo_url="https://github.com/acme/demo",
+        scm_kind="github",
+        default_branch="main",
+    )
+    flow = Flow(
+        workspace_id=ws.id,
+        name="Flow",
+        graph={"nodes": [], "edges": []},
+        is_default=True,
+    )
+    session.add_all([project, flow])
+    await session.flush()
+    run = Run(
+        workspace_id=ws.id,
+        project_id=project.id,
+        flow_id=flow.id,
+        title="Diff run",
+        status="succeeded",
+        dry_run=True,
+        sandbox_path=str(sandbox_path),
+    )
+    session.add(run)
+    await session.commit()
+    await session.refresh(run)
+    return run
+
+
+@pytest.mark.asyncio
+async def test_sandbox_file_returns_file_content(
+    app_and_session: tuple[object, async_sessionmaker[AsyncSession], Path],
+) -> None:
+    app, session_factory, tmp_path = app_and_session
+    sandbox = tmp_path / "sandbox"
+    sandbox.mkdir()
+    target = sandbox / "src" / "app.py"
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text("print('hello')\n", encoding="utf-8")
+
+    async with session_factory() as session:
+        run = await _seed_run(session, sandbox)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        res = await client.get(f"/api/runs/{run.id}/sandbox-file", params={"path": "src/app.py"})
+
+    assert res.status_code == 200
+    payload = res.json()
+    assert payload["path"] == "src/app.py"
+    assert payload["content"] == "print('hello')\n"
+
+
+@pytest.mark.asyncio
+async def test_sandbox_file_rejects_path_traversal(
+    app_and_session: tuple[object, async_sessionmaker[AsyncSession], Path],
+) -> None:
+    app, session_factory, tmp_path = app_and_session
+    sandbox = tmp_path / "sandbox"
+    sandbox.mkdir()
+    (sandbox / "README.md").write_text("ok\n", encoding="utf-8")
+
+    async with session_factory() as session:
+        run = await _seed_run(session, sandbox)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        res = await client.get(f"/api/runs/{run.id}/sandbox-file", params={"path": "../../etc/passwd"})
+
+    assert res.status_code == 400
+    assert "escapes sandbox" in res.text

--- a/apps/api/uv.lock
+++ b/apps/api/uv.lock
@@ -986,7 +986,7 @@ wheels = [
 
 [[package]]
 name = "ouroboros-api"
-version = "0.1.5"
+version = "0.1.6"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },

--- a/apps/web/next-env.d.ts
+++ b/apps/web/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ouroboros-web",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "private": true,
   "scripts": {
     "dev": "next dev -p 3000",

--- a/apps/web/src/app/runs/[id]/page.tsx
+++ b/apps/web/src/app/runs/[id]/page.tsx
@@ -340,8 +340,14 @@ function FileDiffArtifact({
       })
       .catch((err: unknown) => {
         if (!alive) return;
-        const message = err instanceof Error ? err.message : "Failed to load original file";
-        setError(message);
+        // A 404 means the file didn't exist before (e.g. newly-added file).
+        // Fall back to an empty original so the diff still renders correctly.
+        const message = err instanceof Error ? err.message : "";
+        if (message.startsWith("404:")) {
+          setOriginalContent("");
+          return;
+        }
+        setError(message || "Failed to load original file");
       });
     return () => {
       alive = false;
@@ -357,12 +363,21 @@ function FileDiffArtifact({
   }
 
   return (
-    <MonacoDiff
-      original={originalContent}
-      modified={artifact.inline_content || ""}
-      language={inferLanguageFromPath(path)}
-      showModeToggle
-    />
+    <>
+      {artifact.meta?.truncated && (
+        <Box style={{ marginBottom: 4 }}>
+          <Text size="1" color="orange">
+            Proposed file content was too large and has been truncated to the last 20,000 characters.
+          </Text>
+        </Box>
+      )}
+      <MonacoDiff
+        original={originalContent}
+        modified={artifact.inline_content || ""}
+        language={inferLanguageFromPath(path)}
+        showModeToggle
+      />
+    </>
   );
 }
 

--- a/apps/web/src/app/runs/[id]/page.tsx
+++ b/apps/web/src/app/runs/[id]/page.tsx
@@ -247,7 +247,16 @@ function StepRow({ step }: { step: RunStep; active: boolean }) {
 }
 
 function StepDetail({ runId, step, events }: { runId: string; step: RunStep; events: RunEvent[] }) {
-  const [artifacts, setArtifacts] = useState<Array<{ id: string; kind: string; name: string; inline_content: string | null }>>([]);
+  const [artifacts, setArtifacts] = useState<
+    Array<{
+      id: string;
+      kind: string;
+      name: string;
+      inline_content: string | null;
+      path?: string | null;
+      meta?: Record<string, unknown>;
+    }>
+  >([]);
   const [open, setOpen] = useState(false);
 
   useEffect(() => {
@@ -287,7 +296,7 @@ function StepDetail({ runId, step, events }: { runId: string; step: RunStep; eve
                 </Flex>
                 {a.kind === "file_diff" ? (
                   <Box style={{ height: 200, marginTop: 6 }}>
-                    <MonacoDiff original="" modified={a.inline_content || ""} language="diff" />
+                    <FileDiffArtifact runId={runId} artifact={a} />
                   </Box>
                 ) : (
                   <pre style={{ margin: 0, fontSize: 12, maxHeight: 220, overflow: "auto", whiteSpace: "pre-wrap" }}>
@@ -301,4 +310,77 @@ function StepDetail({ runId, step, events }: { runId: string; step: RunStep; eve
       )}
     </Box>
   );
+}
+
+function FileDiffArtifact({
+  runId,
+  artifact,
+}: {
+  runId: string;
+  artifact: { path?: string | null; inline_content: string | null; meta?: Record<string, unknown> };
+}) {
+  const [originalContent, setOriginalContent] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const path = artifact.path || (typeof artifact.meta?.path === "string" ? artifact.meta.path : null);
+
+  useEffect(() => {
+    let alive = true;
+    if (!path) {
+      setError("Missing file path for diff artifact.");
+      return () => {
+        alive = false;
+      };
+    }
+    setError(null);
+    api
+      .get<{ content: string }>(`/api/runs/${runId}/sandbox-file?path=${encodeURIComponent(path)}`)
+      .then((payload) => {
+        if (!alive) return;
+        setOriginalContent(payload.content || "");
+      })
+      .catch((err: unknown) => {
+        if (!alive) return;
+        const message = err instanceof Error ? err.message : "Failed to load original file";
+        setError(message);
+      });
+    return () => {
+      alive = false;
+    };
+  }, [path, runId]);
+
+  if (error) {
+    return (
+      <Box style={{ marginTop: 6 }}>
+        <Text size="1" color="red">{error}</Text>
+      </Box>
+    );
+  }
+
+  return (
+    <MonacoDiff
+      original={originalContent}
+      modified={artifact.inline_content || ""}
+      language={inferLanguageFromPath(path)}
+      showModeToggle
+    />
+  );
+}
+
+function inferLanguageFromPath(path?: string | null): string {
+  const ext = path?.split(".").pop()?.toLowerCase();
+  const byExtension: Record<string, string> = {
+    ts: "typescript",
+    tsx: "typescript",
+    js: "javascript",
+    jsx: "javascript",
+    py: "python",
+    md: "markdown",
+    json: "json",
+    yml: "yaml",
+    yaml: "yaml",
+    css: "css",
+    html: "html",
+    sh: "shell",
+  };
+  return ext ? byExtension[ext] || "plaintext" : "plaintext";
 }

--- a/apps/web/src/components/editors/diff-viewer.tsx
+++ b/apps/web/src/components/editors/diff-viewer.tsx
@@ -1,33 +1,48 @@
 "use client";
 
-import { DiffEditor, Editor } from "@monaco-editor/react";
+import { DiffEditor } from "@monaco-editor/react";
+import { useState } from "react";
 
 interface Props {
   original?: string;
   modified: string;
   language?: string;
   hidden?: boolean;
+  showModeToggle?: boolean;
 }
 
-export function DiffViewer({ original, modified, language = "diff", hidden }: Props) {
-  if (hidden) return <div style={{ display: "none" }} />;
-  if (original === undefined || original === "") {
-    return (
-      <Editor
-        defaultValue={modified}
-        defaultLanguage={language}
-        theme="vs-dark"
-        options={{ readOnly: true, minimap: { enabled: false }, fontSize: 12 }}
-      />
-    );
-  }
+export function DiffViewer({
+  original = "",
+  modified,
+  language = "diff",
+  hidden,
+  showModeToggle = false,
+}: Props) {
+  const [renderSideBySide, setRenderSideBySide] = useState(true);
+
+  if (hidden) return <div className="hidden" />;
   return (
-    <DiffEditor
-      original={original}
-      modified={modified}
-      language={language}
-      theme="vs-dark"
-      options={{ readOnly: true, minimap: { enabled: false }, fontSize: 12 }}
-    />
+    <div className="flex h-full min-h-0 flex-col">
+      {showModeToggle ? (
+        <div className="mb-2 flex justify-end">
+          <button
+            type="button"
+            onClick={() => setRenderSideBySide((value) => !value)}
+            className="rounded border border-zinc-700 px-2 py-1 text-xs text-zinc-100 hover:bg-zinc-800"
+          >
+            {renderSideBySide ? "Unified" : "Side-by-side"}
+          </button>
+        </div>
+      ) : null}
+      <div className="min-h-[160px] flex-1">
+        <DiffEditor
+          original={original}
+          modified={modified}
+          language={language}
+          theme="vs-dark"
+          options={{ readOnly: true, minimap: { enabled: false }, fontSize: 12, renderSideBySide }}
+        />
+      </div>
+    </div>
   );
 }

--- a/public/WHATS_NEW.md
+++ b/public/WHATS_NEW.md
@@ -1,5 +1,6 @@
 # What's New
 
+- Added true dry-run file diffs with Monaco `DiffEditor`, including side-by-side/unified toggle and a sandbox file endpoint with path-traversal protection.
 - Added interrupted-run recovery with persisted run snapshots, automatic startup sweep from `running` to `interrupted`, and a Resume action in run details to continue from the first unfinished step.
 - Added `ouroboros init` to scaffold `.env` and `.env.example` with default `OUROBOROS_DATA_DIR` and `OUROBOROS_DB_URL` values for first-run setup.
 - Added real-time shell step log streaming with per-step live log panes in the run detail timeline.


### PR DESCRIPTION
## What was done and why
- Reworked dry-run `file_diff` artifacts to carry both proposed file content (`inline_content`) and file path metadata, so the UI can render a true original-vs-proposed diff instead of a single unified patch blob.
- Added `GET /api/runs/{id}/sandbox-file?path=...` to read original files from a run sandbox and guarded it against path traversal (`../../etc/passwd` returns 400).
- Updated the run detail UI to fetch sandbox originals per `file_diff` artifact and render Monaco `DiffEditor` with a built-in side-by-side/unified mode toggle.
- Marked roadmap ticket #14 complete, updated `WHATS_NEW.md` and `CHANGELOG.md`, and bumped patch versions for both `apps/web` and `apps/api`.

## How to test
- [x] `yarn build`
- [x] `yarn --cwd apps/web build`
- [x] `yarn --cwd apps/api test tests/test_runs_sandbox_file.py`
- [x] `yarn --cwd apps/api test tests/test_runs_sandbox_file.py tests/test_dry_run.py`
- [ ] `yarn test` *(currently fails in pre-existing web test `src/components/onboarding/wizard.test.tsx`, unrelated to this change)*

## Risk / notes
- For old artifacts that predate `meta.path`, API fallback uses `name` when `kind === file_diff` to preserve compatibility.
- Sandbox file reads depend on persisted `run.sandbox_path`; if unavailable, endpoint returns 404.

Closes #14

Made with [Cursor](https://cursor.com)